### PR TITLE
Windows support

### DIFF
--- a/Makefile.win
+++ b/Makefile.win
@@ -9,7 +9,7 @@
 NMAKE = nmake /$(MAKEFLAGS)
 CFLAGS = /O2 /EHsc /I"sqlite3"
 
-SRC = sqlite3\sqlite3.c c_src\sqlite3_nif.c c_src\queue.c
+SRC = sqlite3\sqlite3.c c_src\sqlite3_nif.c
 
 all: clean priv\sqlite3_nif.dll
 

--- a/guides/windows.md
+++ b/guides/windows.md
@@ -1,0 +1,44 @@
+# Windows Users
+
+> Exqlite uses an [Erlang NIF](https://erlang.org/doc/tutorial/nif.html) under the hood.  
+> Means calling a native implementation in C.  
+> For Windows users this means compiling Exqlite does not magically just work.  
+
+## Requirements
+
+### Install Microsoft Visual C++ Build Tools
+
+Download page:  
+[visualstudio.microsoft.com/visual-cpp-build-tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/)
+
+Alternative direct download link:  
+[aka.ms/vs/16/release/vs_buildtools.exe](https://aka.ms/vs/16/release/vs_buildtools.exe)  
+_for Visual Studio 2019 - version 16_
+
+## Building
+
+### Start command prompt with necessary environment
+
+> Assuming you want to build for Windows x64.
+
+Within Windows Start menu search for:  
+x64 Native Tools Command Prompt
+
+Starting this command prompt all necessary environment variables for compiling should be ready.
+
+Means ready to run:
+```cmd
+mix deps.compile exqlite
+
+# or
+mix compile
+mix test
+```
+
+**Alternative way to start prompt**
+
+Assuming you have _latest_ version of Build Tools (Visual Studio 2019) installed.
+
+```
+cmd /k "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
+```


### PR DESCRIPTION
So this is the quick fix in Makefile.win + a first guide for Windows users.
If this PR is merged I will probably make another PR for adding this page to the docs.
And add a reference within the ecto_sqlite3 docs.

The guide is a opinionated mix of the following sources:
- [elixir/elixir_make - @windows_error_msg](https://github.com/elixir-lang/elixir_make/blob/ab314c374355d34e6b1d4ed953f953b510e0410e/lib/mix/tasks/compile.make.ex#L116-L133)
- [riverrun/comeonin - Wiki - Requirements](https://github.com/riverrun/comeonin/wiki/Requirements)

Possibly interesting for the CI setup:
- [Use the Microsoft C++ toolset from the command line](https://docs.microsoft.com/cpp/build/building-on-the-command-line)
- [Visual Studio Build Tools 2019 Silent Install ](https://silentinstallhq.com/visual-studio-build-tools-2019-silent-install-how-to-guide/)

Close #26