### PR TITLE
Adds multi_step/3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Changelog
 
-## [Unreleased]
+
+## [0.5.2] - 2021-03-23
 
 ### Added
-- Guide for Windows users
+- Guide for Windows users.
+- `Exqlite.Sqlite3.multi_step/3` to step through results chunks at a time.
+
 
 ## [0.5.1] - 2021-03-19
 
@@ -11,15 +14,17 @@
 - Bumped SQLite3 amalgamation to version 3.35.2
 - Replaced old references of [github.com/warmwaffles](http://github.com/warmwaffles)
 
+
 ## [0.5.0] - 2021-03-17
 
 ### Removed
-- Removed `Ecto.Adapters.Exqlite`  
+- Removed `Ecto.Adapters.Exqlite`
   Replaced with [Ecto Sqlite3][ecto_sqlite3] library.
 
 
 [ecto_sqlite3]: <https://github.com/elixir-sqlite/ecto_sqlite3>
 
 [Unreleased]: https://github.com/elixir-sqlite/exqlite/compare/v0.5.1...main
+[0.5.2]: https://github.com/elixir-sqlite/exqlite/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/elixir-sqlite/exqlite/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/elixir-sqlite/exqlite/compare/v0.4.9...v0.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 ### Added
 - Guide for Windows users.
 - `Exqlite.Sqlite3.multi_step/3` to step through results chunks at a time.
-
+- `default_chunk_size` configuration.
 
 ## [0.5.1] - 2021-03-19
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,16 @@ end
 ```
 
 
+## Configuration
+
+```elixir
+config :exqlite, default_chunk_size: 100
+```
+
+* `default_chunk_size` - The chunk size that is used when multi-stepping when
+  not specifying the chunk size explicitly.
+
+
 ## Usage
 
 The `Exqlite.Sqlite3` module usage is fairly straight forward.

--- a/lib/exqlite/sqlite3.ex
+++ b/lib/exqlite/sqlite3.ex
@@ -112,12 +112,12 @@ defmodule Exqlite.Sqlite3 do
     fetch_all(conn, statement, [])
   end
 
-  defp fetch_all(conn, statement, result) do
+  defp fetch_all(conn, statement, accum) do
     case multi_step(conn, statement) do
       :busy -> {:error, "Database busy"}
       {:error, reason} -> {:error, reason}
-      {:done, rows} -> {:ok, result ++ Enum.reverse(rows)}
-      {:rows, rows} -> fetch_all(conn, statement, result ++ Enum.reverse(rows))
+      {:done, rows} -> {:ok, accum ++ Enum.reverse(rows)}
+      {:rows, rows} -> fetch_all(conn, statement, accum ++ Enum.reverse(rows))
     end
   end
 

--- a/lib/exqlite/sqlite3.ex
+++ b/lib/exqlite/sqlite3.ex
@@ -115,17 +115,17 @@ defmodule Exqlite.Sqlite3 do
   end
 
   @spec fetch_all(db(), statement()) :: {:ok, []} | {:error, reason()}
-  def fetch_all(conn, statement) do
+  def fetch_all(conn, statement, chunk_size \\ 50) do
     # TODO: Should this be done in the NIF? It can be _much_ faster to build a
     # list there, but at the expense that it could block other dirty nifs from
     # getting work done.
     #
     # For now this just works
-    fetch_all(conn, statement, [])
+    fetch_all(conn, statement, chunk_size, [])
   end
 
-  defp fetch_all(conn, statement, accum) do
-    case multi_step(conn, statement) do
+  defp fetch_all(conn, statement, chunk_size, accum) do
+    case multi_step(conn, statement, chunk_size) do
       {:done, rows} ->
         {:ok, accum ++ rows}
 

--- a/lib/exqlite/sqlite3_nif.ex
+++ b/lib/exqlite/sqlite3_nif.ex
@@ -37,6 +37,10 @@ defmodule Exqlite.Sqlite3NIF do
   @spec step(db(), statement()) :: :done | :busy | {:row, []}
   def step(_conn, _statement), do: :erlang.nif_error(:not_loaded)
 
+  @spec multi_step(db(), statement(), integer()) ::
+          :busy | {:rows, [[]]} | {:done, [[]]}
+  def multi_step(_conn, _statement, _chunk_size), do: :erlang.nif_error(:not_loaded)
+
   @spec columns(db(), statement()) :: {:ok, []} | {:error, reason()}
   def columns(_conn, _statement), do: :erlang.nif_error(:not_loaded)
 

--- a/test/exqlite/sqlite3_test.exs
+++ b/test/exqlite/sqlite3_test.exs
@@ -247,7 +247,14 @@ defmodule Exqlite.Sqlite3Test do
 
       {:done, rows} = Sqlite3.multi_step(conn, statement)
 
-      assert rows == [[1, "one"], [2, "two"], [3, "three"], [4, "four"], [5, "five"], [6, "six"]]
+      assert rows == [
+               [1, "one"],
+               [2, "two"],
+               [3, "three"],
+               [4, "four"],
+               [5, "five"],
+               [6, "six"]
+             ]
     end
   end
 

--- a/test/exqlite/sqlite3_test.exs
+++ b/test/exqlite/sqlite3_test.exs
@@ -165,7 +165,8 @@ defmodule Exqlite.Sqlite3Test do
       :ok = Sqlite3.execute(conn, "insert into test (stuff) values ('Another test')")
       {:ok, 2} = Sqlite3.last_insert_rowid(conn)
 
-      {:ok, statement} = Sqlite3.prepare(conn, "select id, stuff from test order by id asc")
+      {:ok, statement} =
+        Sqlite3.prepare(conn, "select id, stuff from test order by id asc")
 
       {:row, columns} = Sqlite3.step(conn, statement)
       assert [1, "This is a test"] == columns
@@ -209,16 +210,20 @@ defmodule Exqlite.Sqlite3Test do
       :ok =
         Sqlite3.execute(conn, "create table test (id integer primary key, stuff text)")
 
-      :ok = Sqlite3.execute(conn, "insert into test (stuff) values ('This is a test')")
-      {:ok, 1} = Sqlite3.last_insert_rowid(conn)
-      :ok = Sqlite3.execute(conn, "insert into test (stuff) values ('Another test')")
-      {:ok, 2} = Sqlite3.last_insert_rowid(conn)
+      :ok = Sqlite3.execute(conn, "insert into test (stuff) values ('one')")
+      :ok = Sqlite3.execute(conn, "insert into test (stuff) values ('two')")
+      :ok = Sqlite3.execute(conn, "insert into test (stuff) values ('three')")
+      :ok = Sqlite3.execute(conn, "insert into test (stuff) values ('four')")
+      :ok = Sqlite3.execute(conn, "insert into test (stuff) values ('five')")
+      :ok = Sqlite3.execute(conn, "insert into test (stuff) values ('six')")
 
-      {:ok, statement} = Sqlite3.prepare(conn, "select id, stuff from test")
+      {:ok, statement} =
+        Sqlite3.prepare(conn, "select id, stuff from test order by id asc")
 
-      {:done, rows} = Sqlite3.multi_step(conn, statement)
-      assert [[1, "This is a test"], [2, "Another test"]] == columns
-      assert {:done, []} = Sqlite3.step(conn, statement)
+      {:rows, rows} = Sqlite3.multi_step(conn, statement, 4)
+      assert rows == [[1, "one"], [2, "two"], [3, "three"], [4, "four"]]
+      {:done, rows} = Sqlite3.multi_step(conn, statement, 4)
+      assert rows == [[5, "five"], [6, "six"]]
     end
   end
 

--- a/test/exqlite/sqlite3_test.exs
+++ b/test/exqlite/sqlite3_test.exs
@@ -222,8 +222,32 @@ defmodule Exqlite.Sqlite3Test do
 
       {:rows, rows} = Sqlite3.multi_step(conn, statement, 4)
       assert rows == [[1, "one"], [2, "two"], [3, "three"], [4, "four"]]
+
       {:done, rows} = Sqlite3.multi_step(conn, statement, 4)
       assert rows == [[5, "five"], [6, "six"]]
+    end
+  end
+
+  describe ".multi_step/2" do
+    test "returns results" do
+      {:ok, conn} = Sqlite3.open(":memory:")
+
+      :ok =
+        Sqlite3.execute(conn, "create table test (id integer primary key, stuff text)")
+
+      :ok = Sqlite3.execute(conn, "insert into test (stuff) values ('one')")
+      :ok = Sqlite3.execute(conn, "insert into test (stuff) values ('two')")
+      :ok = Sqlite3.execute(conn, "insert into test (stuff) values ('three')")
+      :ok = Sqlite3.execute(conn, "insert into test (stuff) values ('four')")
+      :ok = Sqlite3.execute(conn, "insert into test (stuff) values ('five')")
+      :ok = Sqlite3.execute(conn, "insert into test (stuff) values ('six')")
+
+      {:ok, statement} =
+        Sqlite3.prepare(conn, "select id, stuff from test order by id asc")
+
+      {:done, rows} = Sqlite3.multi_step(conn, statement)
+
+      assert rows == [[1, "one"], [2, "two"], [3, "three"], [4, "four"], [5, "five"], [6, "six"]]
     end
   end
 

--- a/test/exqlite/sqlite3_test.exs
+++ b/test/exqlite/sqlite3_test.exs
@@ -165,7 +165,7 @@ defmodule Exqlite.Sqlite3Test do
       :ok = Sqlite3.execute(conn, "insert into test (stuff) values ('Another test')")
       {:ok, 2} = Sqlite3.last_insert_rowid(conn)
 
-      {:ok, statement} = Sqlite3.prepare(conn, "select id, stuff from test")
+      {:ok, statement} = Sqlite3.prepare(conn, "select id, stuff from test order by id asc")
 
       {:row, columns} = Sqlite3.step(conn, statement)
       assert [1, "This is a test"] == columns

--- a/test/exqlite/sqlite3_test.exs
+++ b/test/exqlite/sqlite3_test.exs
@@ -202,6 +202,26 @@ defmodule Exqlite.Sqlite3Test do
     end
   end
 
+  describe ".multi_step/3" do
+    test "returns results" do
+      {:ok, conn} = Sqlite3.open(":memory:")
+
+      :ok =
+        Sqlite3.execute(conn, "create table test (id integer primary key, stuff text)")
+
+      :ok = Sqlite3.execute(conn, "insert into test (stuff) values ('This is a test')")
+      {:ok, 1} = Sqlite3.last_insert_rowid(conn)
+      :ok = Sqlite3.execute(conn, "insert into test (stuff) values ('Another test')")
+      {:ok, 2} = Sqlite3.last_insert_rowid(conn)
+
+      {:ok, statement} = Sqlite3.prepare(conn, "select id, stuff from test")
+
+      {:done, rows} = Sqlite3.multi_step(conn, statement)
+      assert [[1, "This is a test"], [2, "Another test"]] == columns
+      assert {:done, []} = Sqlite3.step(conn, statement)
+    end
+  end
+
   describe "working with prepared statements after close" do
     test "returns proper error" do
       {:ok, conn} = Sqlite3.open(":memory:")


### PR DESCRIPTION
Related to the error I encountered with #127.

This does not fix the issue where a timeout causes a `sigsegv`. This just kicks the can further down the road.

This should also cause ecto_sqlite3 to bump this as a dependency to pickup the next change.