### PR TITLE
Add priv dir to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,31 +1,20 @@
-# The directory Mix will write compiled artifacts to.
 /_build/
-
-# If you run "mix test --cover", coverage assets end up here.
 /cover/
-
-# The directory Mix downloads your dependencies sources to.
 /deps/
-
-# Where third-party dependencies like ExDoc output generated docs.
 /doc/
-
-# Ignore .fetch files in case you like to edit your project deps locally.
 /.fetch
 
-# If the VM crashes, it generates a dump, let's ignore it too.
 erl_crash.dump
-
-# Also ignore archive artifacts (built via "mix archive.build").
 *.ez
 
+/priv/
+
 *.o
+*.obj
 
 # Ignore package tarball (built via "mix hex.build").
 exqlite-*.tar
 
-
-# Temporary files for e.g. tests
+# Temporary files for example tests
 /tmp
-
 *.db


### PR DESCRIPTION
Additionally add *.obj files created building on Windows.

I'm not certain if "priv" in .gitignore will make any problems for hex uploads.
But I don't think so as argon2_elixir seems to do the same.