### PR TITLE
Fix segfault on multiple connection closing (closes #161)

### DIFF
--- a/c_src/sqlite3_nif.c
+++ b/c_src/sqlite3_nif.c
@@ -154,6 +154,11 @@ exqlite_close(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
         return make_error_tuple(env, "invalid_connection");
     }
 
+    // DB is already closed, nothing to do here
+    if (conn->db == NULL) {
+        return make_atom(env, "ok");
+    }
+
     int autocommit = sqlite3_get_autocommit(conn->db);
     if (autocommit == 0) {
         rc = sqlite3_exec(conn->db, "ROLLBACK;", NULL, NULL, NULL);

--- a/test/exqlite/sqlite3_test.exs
+++ b/test/exqlite/sqlite3_test.exs
@@ -25,6 +25,12 @@ defmodule Exqlite.Sqlite3Test do
       {:ok, conn} = Sqlite3.open(":memory:")
       :ok = Sqlite3.close(conn)
     end
+
+    test "closing a database multiple times works properly" do
+      {:ok, conn} = Sqlite3.open(":memory:")
+      :ok = Sqlite3.close(conn)
+      :ok = Sqlite3.close(conn)
+    end
   end
 
   describe ".execute/2" do


### PR DESCRIPTION
Problem: 
- As described in https://github.com/elixir-sqlite/exqlite/issues/161, closing a connection more than once leads to a SIGSEGV termination


Solution: 
- check if conn->db is already NULL while closing and return early
+ test case for double connection closing