### PR TITLE
Support Android compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,8 +44,13 @@ PRIV_DIR = $(MIX_APP_PATH)/priv
 LIB_NAME = $(PRIV_DIR)/sqlite3_nif.so
 
 ifneq ($(CROSSCOMPILE),)
-	LIB_CFLAGS := -shared -fPIC -fvisibility=hidden
-	SO_LDFLAGS := -Wl,-soname,libsqlite3.so.0
+	ifeq ($(CROSSCOMPILE), Android)
+		LIB_CFLAGS := -shared -fPIC -fvisibility=hidden
+		SO_LDFLAGS := -Wl,-soname,libsqlite3.so.0 -lm
+	else
+		LIB_CFLAGS := -shared -fPIC -fvisibility=hidden
+		SO_LDFLAGS := -Wl,-soname,libsqlite3.so.0
+	endif
 else
 	ifeq ($(KERNEL_NAME), Linux)
 		LIB_CFLAGS := -shared -fPIC -fvisibility=hidden

--- a/Makefile
+++ b/Makefile
@@ -45,8 +45,8 @@ LIB_NAME = $(PRIV_DIR)/sqlite3_nif.so
 
 ifneq ($(CROSSCOMPILE),)
 	ifeq ($(CROSSCOMPILE), Android)
-		LIB_CFLAGS := -shared -fPIC -fvisibility=hidden
-		SO_LDFLAGS := -Wl,-soname,libsqlite3.so.0 -lm
+		LIB_CFLAGS := -shared -fPIC -Os -z global
+		SO_LDFLAGS := -lm
 	else
 		LIB_CFLAGS := -shared -fPIC -fvisibility=hidden
 		SO_LDFLAGS := -Wl,-soname,libsqlite3.so.0


### PR DESCRIPTION
Hey Guys

I'm using your SQLite nif for my android project https://github.com/elixir-desktop/android-example-app but found that for Android I need to link the nif explicitly again `libm` so I added that under the `$crosscompile` variable when set to 'android'

Additionally, I've added `-Os` to optimize the binary for size and `-z global` though that will not always be needed.

I'm not sure on the reuse of `$crosscompile` since I don't know for what use case you intended it, alternatively I was thinking of using the mix std environment variable `MIX_TARGET` e.g. such as in:
`ifeq ($(MIX_TARGET), Android)`

