### PR TITLE
Added mingw compiler flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,10 @@ else
 	ifeq ($(KERNEL_NAME), Darwin)
 		LIB_CFLAGS := -dynamiclib -undefined dynamic_lookup
 	endif
+	ifeq (MINGW, $(findstring MINGW,$(KERNEL_NAME)))
+		LIB_CFLAGS := -shared -fPIC
+		LIB_NAME = $(PRIV_DIR)/sqlite3_nif.dll
+	endif
 	ifeq ($(KERNEL_NAME), $(filter $(KERNEL_NAME),OpenBSD FreeBSD NetBSD))
 		LIB_CFLAGS := -shared -fPIC
 	endif


### PR DESCRIPTION
This patch allows building on windows using msys2 when the environment variable `MAKE=make`

For windows users it's always difficult to get the compilers working right I'm afraid. What do you think @warmwaffles of including for windows users the DLL in the repo like file_system does for that reason? https://github.com/falood/file_system/tree/master/priv and then decide in mix.exs whether to compile: https://github.com/falood/file_system/blob/acfc8a36b1a1bbb2e64e6451173ed03309812b2c/mix.exs#L47

If you're open to that idea I can prepare a pull requests.