### PR TITLE
Correct typespecs

### DIFF
--- a/lib/exqlite/connection.ex
+++ b/lib/exqlite/connection.ex
@@ -451,6 +451,7 @@ defmodule Exqlite.Connection do
     end
   end
 
+  @spec maybe_changes(Sqlite3.db(), Query.t()) :: integer() | nil
   defp maybe_changes(db, %Query{command: command})
        when command in [:update, :insert, :delete] do
     case Sqlite3.changes(db) do

--- a/lib/exqlite/sqlite3.ex
+++ b/lib/exqlite/sqlite3.ex
@@ -46,7 +46,6 @@ defmodule Exqlite.Sqlite3 do
     case Sqlite3NIF.execute(conn, String.to_charlist(sql)) do
       :ok -> :ok
       {:error, reason} -> {:error, reason}
-      # _ -> {:error, "unhandled error"}
     end
   end
 
@@ -91,7 +90,6 @@ defmodule Exqlite.Sqlite3 do
     case Sqlite3NIF.multi_step(conn, statement, chunk_size) do
       :busy ->
         :busy
-        # {:error, "Database busy"}
 
       {:error, reason} ->
         {:error, reason}

--- a/lib/exqlite/sqlite3_nif.ex
+++ b/lib/exqlite/sqlite3_nif.ex
@@ -10,6 +10,7 @@ defmodule Exqlite.Sqlite3NIF do
   @type db() :: reference()
   @type statement() :: reference()
   @type reason() :: :atom | String.Chars.t()
+  @type row() :: list()
 
   def load_nif() do
     path = :filename.join(:code.priv_dir(:exqlite), 'sqlite3_nif')
@@ -25,24 +26,24 @@ defmodule Exqlite.Sqlite3NIF do
   @spec execute(db(), String.Chars.t()) :: :ok | {:error, reason()}
   def execute(_conn, _sql), do: :erlang.nif_error(:not_loaded)
 
-  @spec changes(db()) :: {:ok, integer()}
+  @spec changes(db()) :: {:ok, integer()} | {:error, reason()}
   def changes(_conn), do: :erlang.nif_error(:not_loaded)
 
   @spec prepare(db(), String.Chars.t()) :: {:ok, statement()} | {:error, reason()}
   def prepare(_conn, _sql), do: :erlang.nif_error(:not_loaded)
 
-  @spec bind(db(), statement(), []) ::
+  @spec bind(db(), statement(), list()) ::
           :ok | {:error, reason()} | {:error, {atom(), any()}}
   def bind(_conn, _statement, _args), do: :erlang.nif_error(:not_loaded)
 
-  @spec step(db(), statement()) :: :done | :busy | {:row, []}
+  @spec step(db(), statement()) :: :done | :busy | {:row, [row()]} | {:error, reason()}
   def step(_conn, _statement), do: :erlang.nif_error(:not_loaded)
 
   @spec multi_step(db(), statement(), integer()) ::
-          :busy | {:rows, [[]]} | {:done, [[]]}
+          :busy | {:rows, [row()]} | {:done, [row()]} | {:error, reason()}
   def multi_step(_conn, _statement, _chunk_size), do: :erlang.nif_error(:not_loaded)
 
-  @spec columns(db(), statement()) :: {:ok, []} | {:error, reason()}
+  @spec columns(db(), statement()) :: {:ok, list(binary())} | {:error, reason()}
   def columns(_conn, _statement), do: :erlang.nif_error(:not_loaded)
 
   @spec last_insert_rowid(db()) :: {:ok, integer()}
@@ -60,7 +61,7 @@ defmodule Exqlite.Sqlite3NIF do
   @spec release(db(), statement()) :: :ok | {:error, reason()}
   def release(_conn, _statement), do: :erlang.nif_error(:not_loaded)
 
-  @spec enable_load_extension(db(), boolean()) :: :ok | {:error, reason()}
+  @spec enable_load_extension(db(), integer()) :: :ok | {:error, reason()}
   def enable_load_extension(_conn, _flag), do: :erlang.nif_error(:not_loaded)
 
   # TODO: add statement inspection tooling https://sqlite.org/c3ref/expanded_sql.html


### PR DESCRIPTION
This corrects the typespecs, making it work with Dialyzer.

You can add Dialyzer to the project itself in `dev` and `test` environments (but not `prod`) by adding this to `deps()`:

    {:dialyxir, "~> 1.0", only: [:dev, :test], runtime: false}

then run

    mix dialyzer