### PR TITLE
Reduce gcc/Makefile prints to simplify build output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,12 +106,15 @@ all: $(PREFIX) $(BUILD) $(ARCHIVE_NAME)
 endif
 
 $(BUILD)/%.o: c_src/%.c
+	@echo " CC $(notdir $@)"
 	$(CC) -c $(CFLAGS) -o $@ $<
 
 $(LIB_NAME): $(OBJ)
+	@echo " LD $(notdir $@)"
 	$(CC) -o $@ $(LDFLAGS) $^
 
 $(ARCHIVE_NAME): $(OBJ)
+	@echo " AR $(notdir $@)"
 	$(AR) -rv $@ $^
 
 $(PREFIX) $(BUILD):
@@ -121,3 +124,6 @@ clean:
 	$(RM) $(LIB_NAME) $(ARCHIVE_NAME) $(OBJ)
 
 .PHONY: all clean
+
+# Don't echo commands unless the caller exports "V=1"
+${V}.SILENT:


### PR DESCRIPTION
The gcc commandlines and other prints can be useful, but most of the
time they are overwhelming especially for non-C programmers. This
simplifies the prints.

To re-enable, set `V=1` like is common with many Makefile/C projects.
For example `V=1 make`, `V=1 mix compile`, etc.

Example output:

```
> exqlite √ % mix test                                                                                                                                                                                          makefile
 CC sqlite3.o
 LD sqlite3_nif.so
..........................................................

Finished in 0.4 seconds (0.00s async, 0.4s sync)
58 tests, 0 failures

Randomized with seed 523581
```