### PR TITLE
Update sqlite3 to 3.37.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased](unreleased)
+### Changed
+- Update SQLite from [3.37.0](https://www.sqlite.org/releaselog/3_37_0.html) to [3.37.2](https://sqlite.org/releaselog/3_37_2.html)
+
 
 ## [0.8.4] - 2021-12-08
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Package: https://hex.pm/packages/exqlite
 
 ```elixir
 defp deps do
-  {:exqlite, "~> 0.8.4"}
+  {:exqlite, "~> 0.8.5"}
 end
 ```
 

--- a/bin/download_sqlite.sh
+++ b/bin/download_sqlite.sh
@@ -7,12 +7,12 @@ set -e
 # https://www.sqlite.org/src/timeline?r=version-3.36.0
 # VERSION consists of 7 digits, like:3350000 for "3.35.5" or 3360000 for "3.36.0"
 
-VERSION=3370000 # 3.37.0
+VERSION=3370200 # 3.37.2
 
 mkdir -p tmp
 pushd tmp
 
-wget https://sqlite.org/2021/sqlite-autoconf-$VERSION.tar.gz
+wget https://sqlite.org/2022/sqlite-autoconf-$VERSION.tar.gz
 
 tar xvfz sqlite-autoconf-$VERSION.tar.gz
 

--- a/c_src/sqlite3.h
+++ b/c_src/sqlite3.h
@@ -146,9 +146,9 @@ extern "C" {
 ** [sqlite3_libversion_number()], [sqlite3_sourceid()],
 ** [sqlite_version()] and [sqlite_source_id()].
 */
-#define SQLITE_VERSION        "3.37.0"
-#define SQLITE_VERSION_NUMBER 3037000
-#define SQLITE_SOURCE_ID      "2021-11-27 14:13:22 bd41822c7424d393a30e92ff6cb254d25c26769889c1499a18a0b9339f5d6c8a"
+#define SQLITE_VERSION        "3.37.2"
+#define SQLITE_VERSION_NUMBER 3037002
+#define SQLITE_SOURCE_ID      "2022-01-06 13:25:41 872ba256cbf61d9290b571c0e6d82a20c224ca3ad82971edc46b29818d5d17a0"
 
 /*
 ** CAPI3REF: Run-Time Library Version Numbers

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Exqlite.MixProject do
   use Mix.Project
 
-  @version "0.8.4"
+  @version "0.8.5"
 
   def project do
     [


### PR DESCRIPTION
Bumps SQLite3 to version [3.37.2](https://sqlite.org/releaselog/3_37_2.html)