### PR TITLE
Improve performance of `fetch_all/4`

### DIFF
--- a/lib/exqlite/sqlite3.ex
+++ b/lib/exqlite/sqlite3.ex
@@ -135,10 +135,13 @@ defmodule Exqlite.Sqlite3 do
   defp fetch_all(conn, statement, chunk_size, accum) do
     case multi_step(conn, statement, chunk_size) do
       {:done, rows} ->
-        {:ok, accum ++ rows}
+        case accum do
+          [] -> {:ok, rows}
+          accum -> {:ok, (rows ++ accum) |> Enum.reverse()}
+        end
 
       {:rows, rows} ->
-        fetch_all(conn, statement, chunk_size, accum ++ rows)
+        fetch_all(conn, statement, chunk_size, (rows |> Enum.reverse()) ++ accum)
 
       {:error, reason} ->
         {:error, reason}


### PR DESCRIPTION
In Erlang/Elixir appending to a list requires to traverse the whole list first to find it's end which can be quite slow. The recommendation is to prepend the list and reverse to improve performance:
* https://www.erlang.org/doc/efficiency_guide/myths.html#myth--operator--++--is-always-bad
* https://www.wyeworks.com/blog/2019/03/01/to-use-or-not-to-use-the-++-operator-in-elixir/
* https://stackoverflow.com/questions/3232786/how-to-concat-lists-in-erlang-without-creating-nested-lists

--

This PR is trying to use this method to improve performance of `fetch_all/4` (https://github.com/elixir-sqlite/exqlite/issues/199)
* There is an additional improvement that could be made by breaking the existing api for `multi_step` or having an additional private [`multi_step/3`](https://github.com/elixir-sqlite/exqlite/blob/main/lib/exqlite/sqlite3.ex#L100) that does not `Enum.reverse()` rows if we plan to accumulate the result. (We currently reverse additional rows twice)
* Maybe we should move the list-building to C in the long-term, which might come with other problems by adding time to the NIF.

### Benchmarks:
100 records: **1.05x slower**
```
Name                    ips        average  deviation         median         99th %
old_fetch_all        3.91 K      255.84 μs    ±77.49%         257 μs      517.18 μs
new_fetch_all        3.71 K      269.40 μs    ±85.54%      262.92 μs      527.12 μs

Comparison: 
old_fetch_all        3.91 K
new_fetch_all        3.71 K - 1.05x slower +13.57 μs
```

1.000 records: **1.11x  faster**
```
Name                    ips        average  deviation         median         99th %
new_fetch_all        1.00 K        1.00 ms    ±23.28%        0.97 ms        1.83 ms
old_fetch_all        0.90 K        1.11 ms    ±18.62%        1.09 ms        1.72 ms

Comparison: 
new_fetch_all        1.00 K
old_fetch_all        0.90 K - 1.11x slower +0.111 ms
```


10.000 records: **2.10x faster**
```
Name                    ips        average  deviation         median         99th %
new_fetch_all        159.90        6.25 ms    ±14.28%        6.04 ms        9.31 ms
old_fetch_all         76.04       13.15 ms     ±9.02%       13.05 ms       14.71 ms

Comparison: 
new_fetch_all        159.90
old_fetch_all         76.04 - 2.10x slower +6.90 ms
```

100.000 records: **5.23x faster**
```
Name                    ips        average  deviation         median         99th %
new_fetch_all         13.22       75.63 ms     ±7.55%       75.59 ms       91.79 ms
old_fetch_all          2.53      395.56 ms     ±0.84%      395.35 ms      400.38 ms

Comparison: 
new_fetch_all         13.22
old_fetch_all          2.53 - 5.23x slower +319.93 ms
```

1.000.000 records: **73.99x faster**
```
Name                    ips        average  deviation         median         99th %
new_fetch_all          1.38         0.72 s     ±3.95%         0.72 s         0.77 s
old_fetch_all        0.0187        53.46 s     ±0.00%        53.46 s        53.46 s

Comparison: 
new_fetch_all          1.38
old_fetch_all        0.0187 - 73.99x slower +52.74 s
```

<details>
<summary>
Benchmark Code
</summary>

```elixir

path = Temp.path!()
File.rm(path)

{:ok, db} = Exqlite.Sqlite3.open(path)

:ok =
  Exqlite.Sqlite3.execute(db, "create table users (id integer primary key, name text)")

IO.puts("Inserting rows")

Enum.each(1..1000, fn i ->
  IO.puts("Inserting #{i}...")

  :ok =
    Exqlite.Sqlite3.execute(
      db,
      "insert into users (id, name) values (#{i}, 'User-#{i}')"
    )
end)

:ok = Exqlite.Sqlite3.close(db)
IO.puts("inserting done")

Benchee.run(%{
  "old_fetch_all" => fn ->
    {:ok, db} = Exqlite.Sqlite3.open(path)

    {:ok, statement} =
      Exqlite.Sqlite3.prepare(
        db,
        "select * from users"
      )

    {:ok, _rows} = Exqlite.Sqlite3.old_fetch_all(db, statement)
  end,
  "new_fetch_all" => fn ->
    {:ok, db} = Exqlite.Sqlite3.open(path)

    {:ok, statement} =
      Exqlite.Sqlite3.prepare(
        db,
        "select * from users"
      )

    {:ok, _rows} = Exqlite.Sqlite3.fetch_all(db, statement)
  end
})

File.rm(path)
```
</details>