### PR TITLE
Use sqlite3_open_v2

### DIFF
--- a/c_src/sqlite3_nif.c
+++ b/c_src/sqlite3_nif.c
@@ -184,11 +184,12 @@ exqlite_open(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 
     int rc             = 0;
     int size           = 0;
+    int flags;
     connection_t* conn = NULL;
     char filename[MAX_PATHNAME];
     ERL_NIF_TERM result;
 
-    if (argc != 1) {
+    if (argc != 2) {
         return enif_make_badarg(env);
     }
 
@@ -202,7 +203,11 @@ exqlite_open(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
         return make_error_tuple(env, "out_of_memory");
     }
 
-    rc = sqlite3_open(filename, &conn->db);
+    if (!enif_get_int(env, argv[1], &flags)) {
+        return make_error_tuple(env, "invalid flags");
+    }
+
+    rc = sqlite3_open_v2(filename, &conn->db, flags, NULL);
     if (rc != SQLITE_OK) {
         enif_release_resource(conn);
         return make_error_tuple(env, "database_open_failed");
@@ -944,7 +949,7 @@ exqlite_enable_load_extension(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[
 //
 
 static ErlNifFunc nif_funcs[] = {
-  {"open", 1, exqlite_open, ERL_NIF_DIRTY_JOB_IO_BOUND},
+  {"open", 2, exqlite_open, ERL_NIF_DIRTY_JOB_IO_BOUND},
   {"close", 1, exqlite_close, ERL_NIF_DIRTY_JOB_IO_BOUND},
   {"execute", 2, exqlite_execute, ERL_NIF_DIRTY_JOB_IO_BOUND},
   {"changes", 1, exqlite_changes, ERL_NIF_DIRTY_JOB_IO_BOUND},

--- a/lib/exqlite/flags.ex
+++ b/lib/exqlite/flags.ex
@@ -1,0 +1,34 @@
+defmodule Exqlite.Flags do
+  @moduledoc false
+
+  import Bitwise
+
+  @file_open_flags [
+    sqlite_open_readonly: 0x00000001,
+    sqlite_open_readwrite: 0x00000002,
+    sqlite_open_create: 0x00000004,
+    sqlite_open_deleteonclos: 0x00000008,
+    sqlite_open_exclusive: 0x00000010,
+    sqlite_open_autoproxy: 0x00000020,
+    sqlite_open_uri: 0x00000040,
+    sqlite_open_memory: 0x00000080,
+    sqlite_open_main_db: 0x00000100,
+    sqlite_open_temp_db: 0x00000200,
+    sqlite_open_transient_db: 0x00000400,
+    sqlite_open_main_journal: 0x00000800,
+    sqlite_open_temp_journal: 0x00001000,
+    sqlite_open_subjournal: 0x00002000,
+    sqlite_open_super_journal: 0x00004000,
+    sqlite_open_nomutex: 0x00008000,
+    sqlite_open_fullmutex: 0x00010000,
+    sqlite_open_sharedcache: 0x00020000,
+    sqlite_open_privatecache: 0x00040000,
+    sqlite_open_wal: 0x00080000,
+    sqlite_open_nofollow: 0x01000000,
+    sqlite_open_exrescode: 0x02000000
+  ]
+
+  def put_file_open_flags(current_flags \\ 0, flags) do
+    Enum.reduce(flags, current_flags, &(&2 ||| Keyword.fetch!(@file_open_flags, &1)))
+  end
+end

--- a/lib/exqlite/flags.ex
+++ b/lib/exqlite/flags.ex
@@ -3,6 +3,7 @@ defmodule Exqlite.Flags do
 
   import Bitwise
 
+  # https://www.sqlite.org/c3ref/c_open_autoproxy.html
   @file_open_flags [
     sqlite_open_readonly: 0x00000001,
     sqlite_open_readwrite: 0x00000002,

--- a/lib/exqlite/sqlite3.ex
+++ b/lib/exqlite/sqlite3.ex
@@ -12,12 +12,14 @@ defmodule Exqlite.Sqlite3 do
   # Need to figure out if we can just stream results where we use this
   # module as a sink.
 
-  alias Exqlite.{Flags, Sqlite3NIF}
+  alias Exqlite.Flags
+  alias Exqlite.Sqlite3NIF
 
   @type db() :: reference()
   @type statement() :: reference()
   @type reason() :: atom() | String.t()
   @type row() :: list()
+  @type open_opt :: {:mode, :readwrite | :readonly}
 
   @doc """
   Opens a new sqlite database at the Path provided.
@@ -30,7 +32,7 @@ defmodule Exqlite.Sqlite3 do
       or `:readonly` to open it in read-only mode. `:readwrite` will also create
       the database if it doesn't already exist. Defaults to `:readwrite`.
   """
-  @spec open(String.t()) :: {:ok, db()} | {:error, reason()}
+  @spec open(String.t(), [open_opt()]) :: {:ok, db()} | {:error, reason()}
   def open(path, opts \\ []) do
     mode = Keyword.get(opts, :mode, :readwrite)
     Sqlite3NIF.open(String.to_charlist(path), flags_from_mode(mode))

--- a/lib/exqlite/sqlite3.ex
+++ b/lib/exqlite/sqlite3.ex
@@ -22,10 +22,17 @@ defmodule Exqlite.Sqlite3 do
   @doc """
   Opens a new sqlite database at the Path provided.
 
-  If `path` can be `":memory"` to keep the sqlite database in memory.
+  `path` can be `":memory"` to keep the sqlite database in memory.
+
+  ## Options
+
+    * `:mode` - use `:readwrite` to open the database for reading and writing
+      or `:readonly` to open it in read-only mode. `:readwrite` will also create
+      the database if it doesn't already exist. Defaults to `:readwrite`.
   """
   @spec open(String.t()) :: {:ok, db()} | {:error, reason()}
-  def open(path, mode \\ :readwrite) do
+  def open(path, opts \\ []) do
+    mode = Keyword.get(opts, :mode, :readwrite)
     Sqlite3NIF.open(String.to_charlist(path), flags_from_mode(mode))
   end
 

--- a/lib/exqlite/sqlite3.ex
+++ b/lib/exqlite/sqlite3.ex
@@ -12,7 +12,7 @@ defmodule Exqlite.Sqlite3 do
   # Need to figure out if we can just stream results where we use this
   # module as a sink.
 
-  alias Exqlite.Sqlite3NIF
+  alias Exqlite.{Flags, Sqlite3NIF}
 
   @type db() :: reference()
   @type statement() :: reference()
@@ -25,7 +25,20 @@ defmodule Exqlite.Sqlite3 do
   If `path` can be `":memory"` to keep the sqlite database in memory.
   """
   @spec open(String.t()) :: {:ok, db()} | {:error, reason()}
-  def open(path), do: Sqlite3NIF.open(String.to_charlist(path))
+  def open(path, mode \\ :readwrite) do
+    Sqlite3NIF.open(String.to_charlist(path), flags_from_mode(mode))
+  end
+
+  defp flags_from_mode(:readwrite),
+    do: Flags.put_file_open_flags([:sqlite_open_readwrite, :sqlite_open_create])
+
+  defp flags_from_mode(:readonly),
+    do: Flags.put_file_open_flags([:sqlite_open_readonly])
+
+  defp flags_from_mode(mode) do
+    raise ArgumentError,
+          "expected mode to be `:readwrite` or `:readonly`, but received #{inspect(mode)}"
+  end
 
   @spec close(nil) :: :ok
   def close(nil), do: :ok

--- a/lib/exqlite/sqlite3_nif.ex
+++ b/lib/exqlite/sqlite3_nif.ex
@@ -17,8 +17,8 @@ defmodule Exqlite.Sqlite3NIF do
     :erlang.load_nif(path, 0)
   end
 
-  @spec open(String.Chars.t()) :: {:ok, db()} | {:error, reason()}
-  def open(_path), do: :erlang.nif_error(:not_loaded)
+  @spec open(String.Chars.t(), integer()) :: {:ok, db()} | {:error, reason()}
+  def open(_path, _flags), do: :erlang.nif_error(:not_loaded)
 
   @spec close(db()) :: :ok | {:error, reason()}
   def close(_conn), do: :erlang.nif_error(:not_loaded)

--- a/test/exqlite/sqlite3_test.exs
+++ b/test/exqlite/sqlite3_test.exs
@@ -40,7 +40,7 @@ defmodule Exqlite.Sqlite3Test do
       :ok = Sqlite3.execute(rw_conn, insert_value_query)
 
       # Read from database with a readonly connection
-      {:ok, ro_conn} = Sqlite3.open(path, :readonly)
+      {:ok, ro_conn} = Sqlite3.open(path, [mode: :readonly])
 
       select_query = "select id, stuff from test order by id asc"
       {:ok, statement} = Sqlite3.prepare(ro_conn, select_query)
@@ -60,7 +60,7 @@ defmodule Exqlite.Sqlite3Test do
         "expected mode to be `:readwrite` or `:readonly`, but received :notarealmode"
 
       assert_raise ArgumentError, msg, fn ->
-        Sqlite3.open(path, :notarealmode)
+        Sqlite3.open(path, [mode: :notarealmode])
       end
     end
   end

--- a/test/exqlite/sqlite3_test.exs
+++ b/test/exqlite/sqlite3_test.exs
@@ -40,7 +40,7 @@ defmodule Exqlite.Sqlite3Test do
       :ok = Sqlite3.execute(rw_conn, insert_value_query)
 
       # Read from database with a readonly connection
-      {:ok, ro_conn} = Sqlite3.open(path, [mode: :readonly])
+      {:ok, ro_conn} = Sqlite3.open(path, mode: :readonly)
 
       select_query = "select id, stuff from test order by id asc"
       {:ok, statement} = Sqlite3.prepare(ro_conn, select_query)
@@ -60,7 +60,7 @@ defmodule Exqlite.Sqlite3Test do
         "expected mode to be `:readwrite` or `:readonly`, but received :notarealmode"
 
       assert_raise ArgumentError, msg, fn ->
-        Sqlite3.open(path, [mode: :notarealmode])
+        Sqlite3.open(path, mode: :notarealmode)
       end
     end
   end

--- a/test/exqlite/sqlite3_test.exs
+++ b/test/exqlite/sqlite3_test.exs
@@ -49,7 +49,7 @@ defmodule Exqlite.Sqlite3Test do
       assert [1, "This is a test"] == columns
 
       # Readonly connection cannot insert
-      assert {:error, "attempt to write a readonly database"} =
+      assert {:error, "attempt to write a readonly database"} ==
                Sqlite3.execute(ro_conn, insert_value_query)
     end
 

--- a/test/exqlite/sqlite3_test.exs
+++ b/test/exqlite/sqlite3_test.exs
@@ -27,6 +27,42 @@ defmodule Exqlite.Sqlite3Test do
 
       File.rm(path)
     end
+
+    test "opens a database in readonly mode" do
+      # Create database with readwrite connection
+      {:ok, path} = Temp.path()
+      {:ok, rw_conn} = Sqlite3.open(path)
+
+      create_table_query = "create table test (id integer primary key, stuff text)"
+      :ok = Sqlite3.execute(rw_conn, create_table_query)
+
+      insert_value_query = "insert into test (stuff) values ('This is a test')"
+      :ok = Sqlite3.execute(rw_conn, insert_value_query)
+
+      # Read from database with a readonly connection
+      {:ok, ro_conn} = Sqlite3.open(path, :readonly)
+
+      select_query = "select id, stuff from test order by id asc"
+      {:ok, statement} = Sqlite3.prepare(ro_conn, select_query)
+      {:row, columns} = Sqlite3.step(ro_conn, statement)
+
+      assert [1, "This is a test"] == columns
+
+      # Readonly connection cannot insert
+      assert {:error, "attempt to write a readonly database"} =
+               Sqlite3.execute(ro_conn, insert_value_query)
+    end
+
+    test "opens a database with invalid mode" do
+      {:ok, path} = Temp.path()
+
+      msg =
+        "expected mode to be `:readwrite` or `:readonly`, but received :notarealmode"
+
+      assert_raise ArgumentError, msg, fn ->
+        Sqlite3.open(path, :notarealmode)
+      end
+    end
   end
 
   describe ".close/2" do


### PR DESCRIPTION
Closes https://github.com/elixir-sqlite/exqlite/issues/149

- Uses `sqlite3_open_v2` instead of `sqlite3_open` inside of the nif.
- Exposes an optional second argument to `Exqlite.Sqlite3.open` to specify options, with `:mode` being one of them. `:mode`  defaults to `:readwrite` (the existing behaviour, including creating the db if it doesn't exist) and also allows `:readonly`. There are a bunch of flags that can be used for open_v2 so that's why I made this `opts` instead of a single argument for mode.

If merged I can make a change to the ecto adapter to allow it to utilize the new parameter to `Exqlite.Sqlite3.open`