### PR TITLE
Fix android build adding `-lm` to LD_FLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ OBJ = $(SRC:c_src/%.c=$(BUILD)/%.o)
 ifneq ($(CROSSCOMPILE),)
 	ifeq ($(CROSSCOMPILE), Android)
 		CFLAGS += -fPIC -Os -z global
-		LDFLAGS += -fPIC -shared
+		LDFLAGS += -fPIC -shared -lm
 	else
 		CFLAGS += -fPIC -fvisibility=hidden
 		LDFLAGS += -fPIC -shared


### PR DESCRIPTION
This got somewhere lost between 0.7.5 and the current master. But on android we need to explicitly link against libm to resolve `acos` and other math symbols