### PR TITLE
Update sqlite3 to 3.39.4

### DIFF
--- a/c_src/sqlite3.h
+++ b/c_src/sqlite3.h
@@ -146,9 +146,9 @@ extern "C" {
 ** [sqlite3_libversion_number()], [sqlite3_sourceid()],
 ** [sqlite_version()] and [sqlite_source_id()].
 */
-#define SQLITE_VERSION        "3.39.3"
-#define SQLITE_VERSION_NUMBER 3039003
-#define SQLITE_SOURCE_ID      "2022-09-05 11:02:23 4635f4a69c8c2a8df242b384a992aea71224e39a2ccab42d8c0b0602f1e826e8"
+#define SQLITE_VERSION        "3.39.4"
+#define SQLITE_VERSION_NUMBER 3039004
+#define SQLITE_SOURCE_ID      "2022-09-29 15:55:41 a29f9949895322123f7c38fbe94c649a9d6e6c9cd0c3b41c96d694552f26b309"
 
 /*
 ** CAPI3REF: Run-Time Library Version Numbers

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Exqlite.MixProject do
   use Mix.Project
 
   @version "0.11.5"
-  @sqlite_version "3.39.3"
+  @sqlite_version "3.39.4"
 
   def project do
     [


### PR DESCRIPTION
Just got an email about this one.

> SQLite version 3.39.4 is now available on the website:
> 
>  https://sqlite.org/index.html
>  https://sqlite.org/download.html
> 
> Version 3.39.4 is a minimal patch against the prior release that addresses issues found since the prior release.  In particular, a potential vulnerability in the FTS3 extension has been fixed, so this should be considered a security update.
> 
> In order to exploit the vulnerability, an attacker must have full SQL access and must be able to construct a corrupt database with over 2GB of FTS3 content.  The problem arises from a 32-bit signed integer overflow.