### PR TITLE
Fix segfault when database connections timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
       matrix:
         os: ["ubuntu-20.04", "windows-2019"]
         elixir: ["1.14", "1.13", "1.12", "1.11"]
-        otp: ["25", 24", "23"]
+        otp: ["25", "24", "23"]
         exclude:
           - otp: "25"
             os: "windows-2019"

--- a/test/exqlite/timeout_segfault_test.exs
+++ b/test/exqlite/timeout_segfault_test.exs
@@ -1,6 +1,8 @@
 defmodule Exqlite.TimeoutSegfaultTest do
   use ExUnit.Case
 
+  @moduletag :slow_test
+
   setup do
     {:ok, path} = Temp.path()
     on_exit(fn -> File.rm(path) end)

--- a/test/exqlite/timeout_segfault_test.exs
+++ b/test/exqlite/timeout_segfault_test.exs
@@ -1,0 +1,39 @@
+defmodule Exqlite.TimeoutSegfaultTest do
+  use ExUnit.Case
+
+  setup do
+    {:ok, path} = Temp.path()
+    on_exit(fn -> File.rm(path) end)
+
+    %{path: path}
+  end
+
+  test "segfault", %{path: path} do
+    {:ok, conn} =
+      DBConnection.start_link(Exqlite.Connection,
+        busy_timeout: 50000,
+        pool_size: 50,
+        timeout: 1,
+        database: path,
+        journal_mode: :wal
+      )
+
+    query = %Exqlite.Query{statement: "create table foo(id integer, val integer)"}
+    {:ok, _, _} = DBConnection.execute(conn, query, [])
+
+    values = for i <- 1..1000, do: "(#{i}, #{i})"
+    statement = "insert into foo(id, val) values #{Enum.join(values, ",")}"
+    insert_query = %Exqlite.Query{statement: statement}
+
+    1..5000
+    |> Task.async_stream(fn _ ->
+      try do
+        DBConnection.execute(conn, insert_query, [], timeout: 1)
+      catch
+        kind, reason ->
+          IO.inspect("#{inspect(kind)} #{inspect(reason)}", label: "Error")
+      end
+    end)
+    |> Stream.run()
+  end
+end

--- a/test/exqlite/timeout_segfault_test.exs
+++ b/test/exqlite/timeout_segfault_test.exs
@@ -13,7 +13,7 @@ defmodule Exqlite.TimeoutSegfaultTest do
   test "segfault", %{path: path} do
     {:ok, conn} =
       DBConnection.start_link(Exqlite.Connection,
-        busy_timeout: 50000,
+        busy_timeout: 50_000,
         pool_size: 50,
         timeout: 1,
         database: path,
@@ -33,7 +33,7 @@ defmodule Exqlite.TimeoutSegfaultTest do
         DBConnection.execute(conn, insert_query, [], timeout: 1)
       catch
         kind, reason ->
-          IO.inspect("#{inspect(kind)} #{inspect(reason)}", label: "Error")
+          IO.puts("Error: #{inspect(kind)} reason: #{inspect(reason)}")
       end
     end)
     |> Stream.run()

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,1 @@
-ExUnit.start(capture_log: true)
+ExUnit.start(capture_log: true, timeout: 120_000)

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,1 @@
-ExUnit.start(capture_log: true, timeout: 120_000)
+ExUnit.start(capture_log: true, timeout: 120_000, exclude: [:slow_test])


### PR DESCRIPTION
### Hypothesis
the issue seems to be that there is a race condition between `exqlite_close` and `exqlite_prepare`. The issue happens when we execute `sqlite3_prepare_v3` on a connection after we close the connection with `sqlite3_close_v2`. 

`sqlite3_close_v2` does handle previously prepared statements, but here we are preparing the statement in-parallel while we are closing the connection. Which is causing occasional [SQLITE_MISUSE](https://www.sqlite.org/rescode.html#misuse).

How can we reach this state?

**Given**
* `exqlite_close` is executed by connection process
* while `handle_prepare` and other callbacks are called in the client process
* a NIF call can not be interrupted/cancelled [once started](https://www.erlang.org/doc/man/erl_nif.html), irrespective of client side process timeout, or process kill.

## Scenario 

1. client checkout a connection and makes a query
2. client makes `exqlite_prepare` NIF call but fail to complete within connection timeout duration. It 1ms in the test case. This NIF call is still running or scheduled to run even after the timeout.
3. due to connection timeout, connection-process receives timeout and initiate connection close (`disconnect` callback)
4. connection-process calls `exqlite_close` NIF 


2 & 4 are run in-parallel leading to race-condition mentioned previously causing segfault.

## Fix

I tried to fix the race-condition using mutex, and sofar haven't seen a single failure. 

This is PoC, I guess we should handle multiple other cases as well, not just the one between close & prepare if this is the issue.

Should fix https://github.com/elixir-sqlite/exqlite/issues/190

