### PR TITLE
Allow setting custom pragmas

### DIFF
--- a/test/exqlite/connection_test.exs
+++ b/test/exqlite/connection_test.exs
@@ -83,6 +83,24 @@ defmodule Exqlite.ConnectionTest do
       File.rm(path)
     end
 
+    test "setting custom_pragmas" do
+      path = Temp.path!()
+
+      {:ok, state} =
+        Connection.connect(
+          database: path,
+          custom_pragmas: [
+            checkpoint_fullfsync: 0
+          ]
+        )
+
+      assert state.db
+
+      assert {:ok, 0} = get_pragma(state.db, :checkpoint_fullfsync)
+
+      File.rm(path)
+    end
+
     test "setting journal_size_limit" do
       path = Temp.path!()
       size_limit = 20 * 1024 * 1024


### PR DESCRIPTION
This allows for someone to set any PRAGMA keys and values, next to the most common ones. See the documentation for a full list: https://www2.sqlite.org/draft/pragma.html

One use-case is to set the `cipher_compatibility` PRAGMA which is supported by the SQLCipher extension:
https://www.zetetic.net/sqlcipher/sqlcipher-api/#cipher_compatibility

Fixes #227 