### PR TITLE
docs: how to opt out of precompiled artefacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,26 @@ end
 
 ## Configuration
 
+### Runtime Configuration
+
 ```elixir
 config :exqlite, default_chunk_size: 100
 ```
 
 * `default_chunk_size` - The chunk size that is used when multi-stepping when
   not specifying the chunk size explicitly.
+  
+### Compile-time Configuration
 
+In `config/config.exs`,
+
+```elixir
+config :exqlite, make_force_build: false
+```
+
+* `make_force_build` - Set `true` to opt out of using precompiled artefacts.
+This option only affects the default configuration. For advanced configuation,
+this library will always compile natively.
 
 ## Advanced Configuration
 


### PR DESCRIPTION
Hi @warmwaffles, I split the `Configuration` section into two subsections because I'd like to make it clearer that `make_force_build` is a compile-time option (so that users won't get confused about where they should set it). 

But please let me know if you have a better idea of which section I should mention this. :D