### PR TITLE
Cast all error reasons to String

### DIFF
--- a/lib/exqlite/basic.ex
+++ b/lib/exqlite/basic.ex
@@ -16,7 +16,7 @@ defmodule Exqlite.Basic do
   def close(%Connection{} = conn) do
     case Sqlite3.close(conn.db) do
       :ok -> :ok
-      {:error, reason} -> {:error, %Error{message: reason}}
+      {:error, reason} -> {:error, %Error{message: to_string(reason)}}
     end
   end
 
@@ -30,7 +30,7 @@ defmodule Exqlite.Basic do
         {:ok, rows, columns}
 
       {:error, %Error{message: message}, %Connection{}} ->
-        {:error, message}
+        {:error, to_string(message)}
     end
   end
 

--- a/lib/exqlite/connection.ex
+++ b/lib/exqlite/connection.ex
@@ -166,7 +166,7 @@ defmodule Exqlite.Connection do
   def disconnect(_err, %__MODULE__{db: db}) do
     case Sqlite3.close(db) do
       :ok -> :ok
-      {:error, reason} -> {:error, %Error{message: reason}}
+      {:error, reason} -> {:error, %Error{message: to_string(reason)}}
     end
   end
 
@@ -321,7 +321,7 @@ defmodule Exqlite.Connection do
         {:cont, %Result{rows: rows, command: :fetch, num_rows: chunk_size}, state}
 
       {:error, reason} ->
-        {:error, %Error{message: reason, statement: statement}, state}
+        {:error, %Error{message: to_string(reason), statement: statement}, state}
 
       :busy ->
         {:error, %Error{message: "Database is busy", statement: statement}, state}
@@ -493,7 +493,7 @@ defmodule Exqlite.Connection do
       {:ok, state}
     else
       {:error, reason} ->
-        {:error, %Exqlite.Error{message: reason}}
+        {:error, %Exqlite.Error{message: to_string(reason)}}
     end
   end
 
@@ -514,7 +514,7 @@ defmodule Exqlite.Connection do
       {:ok, query}
     else
       {:error, reason} ->
-        {:error, %Error{message: reason, statement: statement}, state}
+        {:error, %Error{message: to_string(reason), statement: statement}, state}
     end
   end
 
@@ -527,7 +527,7 @@ defmodule Exqlite.Connection do
         {:ok, %{query | ref: ref}}
 
       {:error, reason} ->
-        {:error, %Error{message: reason, statement: statement}, state}
+        {:error, %Error{message: to_string(reason), statement: statement}, state}
     end
   end
 
@@ -590,7 +590,7 @@ defmodule Exqlite.Connection do
         {:ok, query}
 
       {:error, reason} ->
-        {:error, %Error{message: reason, statement: statement}, state}
+        {:error, %Error{message: to_string(reason), statement: statement}, state}
     end
   end
 
@@ -600,7 +600,7 @@ defmodule Exqlite.Connection do
         {:ok, columns}
 
       {:error, reason} ->
-        {:error, %Error{message: reason, statement: statement}, state}
+        {:error, %Error{message: to_string(reason), statement: statement}, state}
     end
   end
 
@@ -610,7 +610,7 @@ defmodule Exqlite.Connection do
         {:ok, rows}
 
       {:error, reason} ->
-        {:error, %Error{message: reason, statement: statement}, state}
+        {:error, %Error{message: to_string(reason), statement: statement}, state}
     end
   end
 
@@ -627,7 +627,7 @@ defmodule Exqlite.Connection do
       {:ok, result, %{state | transaction_status: transaction_status}}
     else
       {:error, reason} ->
-        {:disconnect, %Error{message: reason, statement: statement}, state}
+        {:disconnect, %Error{message: to_string(reason), statement: statement}, state}
     end
   end
 


### PR DESCRIPTION
 I get this error every so often:

```
21:28:43.249 [error] Exqlite.Connection (#PID<0.2627.0>) failed to connect: 
** (Exqlite.Error) got :database_open_failed while retrieving Exception.message/1 
for %Exqlite.Error{message: :database_open_failed, statement: nil} (expected a string)
```

The NIF returns error `reason`'s as atoms, but `Exqlite.Error` expects a String. This PR fixes this issue by wrapping all `reason`'s with `to_string/1`.

Please don't hesitate to take a different approach if you feel another one is more appropriate :heart: 