### PR TITLE
check for closed connection in changes

### DIFF
--- a/c_src/sqlite3_nif.c
+++ b/c_src/sqlite3_nif.c
@@ -341,6 +341,10 @@ exqlite_changes(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
         return make_error_tuple(env, "invalid_connection");
     }
 
+    if (conn->db == NULL) {
+        return make_error_tuple(env, "connection closed");
+    }
+
     int changes = sqlite3_changes(conn->db);
     return make_ok_tuple(env, enif_make_int(env, changes));
 }

--- a/c_src/sqlite3_nif.c
+++ b/c_src/sqlite3_nif.c
@@ -342,7 +342,7 @@ exqlite_changes(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
     }
 
     if (conn->db == NULL) {
-        return make_error_tuple(env, "connection closed");
+        return make_error_tuple(env, "connection_closed");
     }
 
     int changes = sqlite3_changes(conn->db);
@@ -390,7 +390,7 @@ exqlite_prepare(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
     if (conn->db == NULL) {
         enif_mutex_unlock(conn->mutex);
         enif_release_resource(statement);
-        return make_error_tuple(env, "connection closed");
+        return make_error_tuple(env, "connection_closed");
     }
     rc = sqlite3_prepare_v3(conn->db, (char*)bin.data, bin.size, 0, &statement->statement, NULL);
     enif_mutex_unlock(conn->mutex);


### PR DESCRIPTION
Without this, it's possible to have a race condition where a crash happens if an insert query times out; the connection is closed during the `transaction_status`, `changes` follow-up

(Keen for feedback if this principle/check should be extended to any other NIF wrappers)