### PR TITLE
fix: don't bind atoms that are prefixed with `nil` as NULL

### DIFF
--- a/c_src/sqlite3_nif.c
+++ b/c_src/sqlite3_nif.c
@@ -430,7 +430,7 @@ bind(ErlNifEnv* env, const ERL_NIF_TERM arg, sqlite3_stmt* statement, int index)
     }
 
     if (enif_get_atom(env, arg, the_atom, sizeof(the_atom), ERL_NIF_LATIN1)) {
-        if (0 == utf8ncmp("undefined", the_atom, 9) || 0 == utf8ncmp("nil", the_atom, 3)) {
+        if (0 == utf8cmp("undefined", the_atom) || 0 == utf8cmp("nil", the_atom)) {
             return sqlite3_bind_null(statement, index);
         }
 


### PR DESCRIPTION
This patch changes the comparison from `utf8ncmp` to `utf8cmp` in order
to explicitly match on the size of the atom. I noticed a case of
inserting an atom of `:nil_safe?` that was cast to `NULL`.

I wasn't sure the correct level to add a test, so please let me know the
best place and I can get it added.
