### PR TITLE
Add set_update_hook/2

### DIFF
--- a/c_src/sqlite3_nif.c
+++ b/c_src/sqlite3_nif.c
@@ -1061,7 +1061,7 @@ exqlite_set_update_hook(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 
     // Passing the connection as the third argument causes it to be
     // passed as the first argument to update_callback. This allows us
-    // To extract the hook pid and reset the hook if the pid is not alive.
+    // to extract the hook pid and reset the hook if the pid is not alive.
     sqlite3_update_hook(conn->db, update_callback, conn);
 
     return make_atom(env, "ok");

--- a/lib/exqlite/sqlite3.ex
+++ b/lib/exqlite/sqlite3.ex
@@ -223,6 +223,10 @@ defmodule Exqlite.Sqlite3 do
     * Only one pid can listen to the changes on a given database connection at a time.
       If this function is called multiple times for the same connection, only the last pid will
       receive the notifications
+    * Updates only happen for the connection that is opened. For example, there 
+      are two connections A and B. When an update happens on connection B, the
+      hook set for connection A will not receive the update, but the hook for
+      connection B will receive the update.
   """
   @spec set_update_hook(db(), pid()) :: :ok | {:error, reason()}
   def set_update_hook(conn, pid) do

--- a/lib/exqlite/sqlite3.ex
+++ b/lib/exqlite/sqlite3.ex
@@ -203,6 +203,33 @@ defmodule Exqlite.Sqlite3 do
     end
   end
 
+  @doc """
+  Send data change notifications on connection to a process.
+
+  Each time an insert, update, or delete is performed on the
+  connection provided as the first argument, a message will be
+  sent to the pid provided as the second argument.
+
+  The message is of the form: `{action, db_name, table, row_id}`,
+  where:
+
+      * `action` is one of `:insert`, `:update` or `:delete`
+      * `db_name` is a string representing the database name
+         where the change took place
+      * `table` is a string representing the table name where
+         the change took place
+      * `row_id` is an integer representing the unique row id
+         assigned by SQLite
+
+  Note there are some restrictions on the type of changes that can be sent using
+  this method. Check SQlite's documentation
+  [for more details](https://www.sqlite.org/c3ref/update_hook.html).
+  """
+  @spec set_update_hook(db(), pid()) :: :ok | {:error, reason()}
+  def set_update_hook(conn, pid) do
+    Sqlite3NIF.set_update_hook(conn, pid)
+  end
+
   defp convert(%Date{} = val), do: Date.to_iso8601(val)
   defp convert(%Time{} = val), do: Time.to_iso8601(val)
   defp convert(%NaiveDateTime{} = val), do: NaiveDateTime.to_iso8601(val)

--- a/lib/exqlite/sqlite3.ex
+++ b/lib/exqlite/sqlite3.ex
@@ -206,24 +206,23 @@ defmodule Exqlite.Sqlite3 do
   @doc """
   Send data change notifications on connection to a process.
 
-  Each time an insert, update, or delete is performed on the
-  connection provided as the first argument, a message will be
-  sent to the pid provided as the second argument.
+  Each time an insert, update, or delete is performed on the connection provided
+  as the first argument, a message will be sent to the pid provided as the second argument.
 
-  The message is of the form: `{action, db_name, table, row_id}`,
-  where:
+  The message is of the form: `{action, db_name, table, row_id}`, where:
 
-      * `action` is one of `:insert`, `:update` or `:delete`
-      * `db_name` is a string representing the database name
-         where the change took place
-      * `table` is a string representing the table name where
-         the change took place
-      * `row_id` is an integer representing the unique row id
-         assigned by SQLite
+    * `action` is one of `:insert`, `:update` or `:delete`
+    * `db_name` is a string representing the database name where the change took place
+    * `table` is a string representing the table name where the change took place
+    * `row_id` is an integer representing the unique row id assigned by SQLite
 
-  Note there are some restrictions on the type of changes that can be sent using
-  this method. Check SQlite's documentation
-  [for more details](https://www.sqlite.org/c3ref/update_hook.html).
+  ## Restrictions
+
+    * There are some conditions where the update hook will not be invoked by SQLite.
+      See the documentation for [more details](https://www.sqlite.org/c3ref/update_hook.html)
+    * Only one pid can listen to the changes on a given database connection at a time.
+      If this function is called multiple times for the same connection, only the last pid will
+      receive the notifications
   """
   @spec set_update_hook(db(), pid()) :: :ok | {:error, reason()}
   def set_update_hook(conn, pid) do

--- a/lib/exqlite/sqlite3.ex
+++ b/lib/exqlite/sqlite3.ex
@@ -204,7 +204,7 @@ defmodule Exqlite.Sqlite3 do
   end
 
   @doc """
-  Send data change notifications on connection to a process.
+  Send data change notifications to a process.
 
   Each time an insert, update, or delete is performed on the connection provided
   as the first argument, a message will be sent to the pid provided as the second argument.

--- a/lib/exqlite/sqlite3_nif.ex
+++ b/lib/exqlite/sqlite3_nif.ex
@@ -64,5 +64,8 @@ defmodule Exqlite.Sqlite3NIF do
   @spec enable_load_extension(db(), integer()) :: :ok | {:error, reason()}
   def enable_load_extension(_conn, _flag), do: :erlang.nif_error(:not_loaded)
 
+  @spec set_update_hook(db(), pid()) :: :ok | {:error, reason()}
+  def set_update_hook(_conn, _pid), do: :erlang.nif_error(:not_loaded)
+
   # add statement inspection tooling https://sqlite.org/c3ref/expanded_sql.html
 end

--- a/test/exqlite/sqlite3_test.exs
+++ b/test/exqlite/sqlite3_test.exs
@@ -472,8 +472,8 @@ defmodule Exqlite.Sqlite3Test do
     end
 
     test "notifications don't cross connections", context do
-      {:ok, new_conn} = Sqlite3.open(context.path)
       {:ok, listener_pid} = ChangeListener.start_link({self(), :listener})
+      {:ok, new_conn} = Sqlite3.open(context.path)
       Sqlite3.set_update_hook(new_conn, listener_pid)
 
       :ok = Sqlite3.execute(context.conn, "insert into test(num) values (10)")

--- a/test/exqlite/sqlite3_test.exs
+++ b/test/exqlite/sqlite3_test.exs
@@ -475,7 +475,6 @@ defmodule Exqlite.Sqlite3Test do
       {:ok, listener_pid} = ChangeListener.start_link({self(), :listener})
       {:ok, new_conn} = Sqlite3.open(context.path)
       Sqlite3.set_update_hook(new_conn, listener_pid)
-
       :ok = Sqlite3.execute(context.conn, "insert into test(num) values (10)")
       refute_receive {{:insert, "main", "test", 1}, _}, 1000
     end


### PR DESCRIPTION
Closes https://github.com/elixir-sqlite/exqlite/issues/221

I took a stab at this based on how the [erlang sqlite library is handling it](https://github.com/mmzeeman/esqlite/).

The implementation is pretty straight forward. The user supplies a connection and a pid and we create a callback that sends a message to the pid of the form `{:insert | :update | :delete, db_name, table, row_id}` (that's all the information SQLite exposes about the change. For example, you could create a GenServer to listen to the notifications.

Right now, there can only be one pid per database connection. But I think it can probably be extended later to work with a list of pids.