### PR TITLE
Add OTP 26 for CI

### DIFF
--- a/.github/workflows/precompile.yml
+++ b/.github/workflows/precompile.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         os: ["ubuntu-20.04", "windows-2019", "macos-11"]
         elixir: ["1.14"]
-        otp: ["25", "23"]
+        otp: ["26", "25", "23"]
         exclude:
           - os: "windows-2019"
             otp: "23"


### PR DESCRIPTION
This PR addressed #268, adding OTP 26 precompilation support. It will generate precompiled binaries for NIF versions 2.15, 2.16 and 2.17, which should cover from OTP 23 to 26. 

A testing release can be found here: https://github.com/cocoa-xu/exqlite/releases/tag/v0.16.1