### PR TITLE
Add Exqlite.Sqlite3.interrupt/1.

### DIFF
--- a/c_src/sqlite3_nif.c
+++ b/c_src/sqlite3_nif.c
@@ -1129,6 +1129,31 @@ exqlite_set_log_hook(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
     return make_atom(env, "ok");
 }
 
+static ERL_NIF_TERM
+exqlite_interrupt(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    assert(env);
+
+    connection_t* conn     = NULL;
+
+    if (argc != 1) {
+        return enif_make_badarg(env);
+    }
+
+    if (!enif_get_resource(env, argv[0], connection_type, (void**)&conn)) {
+        return make_error_tuple(env, "invalid_connection");
+    }
+
+    // DB is already closed, nothing to do here
+    if (conn->db == NULL) {
+        return make_atom(env, "ok");
+    }
+
+    sqlite3_interrupt(conn->db);
+
+    return make_atom(env, "ok");
+}
+
 //
 // Most of our nif functions are going to be IO bounded
 //
@@ -1151,6 +1176,7 @@ static ErlNifFunc nif_funcs[] = {
   {"enable_load_extension", 2, exqlite_enable_load_extension, ERL_NIF_DIRTY_JOB_IO_BOUND},
   {"set_update_hook", 2, exqlite_set_update_hook, ERL_NIF_DIRTY_JOB_IO_BOUND},
   {"set_log_hook", 1, exqlite_set_log_hook, ERL_NIF_DIRTY_JOB_IO_BOUND},
+  {"interrupt", 1, exqlite_interrupt, ERL_NIF_DIRTY_JOB_IO_BOUND},
 };
 
 ERL_NIF_INIT(Elixir.Exqlite.Sqlite3NIF, nif_funcs, on_load, NULL, NULL, on_unload)

--- a/c_src/sqlite3_nif.c
+++ b/c_src/sqlite3_nif.c
@@ -1129,6 +1129,9 @@ exqlite_set_log_hook(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
     return make_atom(env, "ok");
 }
 
+///
+/// @brief Interrupt a long-running query.
+///
 static ERL_NIF_TERM
 exqlite_interrupt(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 {

--- a/c_src/sqlite3_nif.c
+++ b/c_src/sqlite3_nif.c
@@ -1137,7 +1137,7 @@ exqlite_interrupt(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 {
     assert(env);
 
-    connection_t* conn     = NULL;
+    connection_t* conn = NULL;
 
     if (argc != 1) {
         return enif_make_badarg(env);

--- a/lib/exqlite/sqlite3.ex
+++ b/lib/exqlite/sqlite3.ex
@@ -57,6 +57,13 @@ defmodule Exqlite.Sqlite3 do
   def close(conn), do: Sqlite3NIF.close(conn)
 
   @doc """
+  Interrupt a long-running query.
+  """
+  @spec interrupt(db() | nil) :: :ok | {:error, reason()}
+  def interrupt(nil), do: :ok
+  def interrupt(conn), do: Sqlite3NIF.interrupt(conn)
+
+  @doc """
   Executes an sql script. Multiple stanzas can be passed at once.
   """
   @spec execute(db(), String.t()) :: :ok | {:error, reason()}

--- a/lib/exqlite/sqlite3_nif.ex
+++ b/lib/exqlite/sqlite3_nif.ex
@@ -23,6 +23,9 @@ defmodule Exqlite.Sqlite3NIF do
   @spec close(db()) :: :ok | {:error, reason()}
   def close(_conn), do: :erlang.nif_error(:not_loaded)
 
+  @spec interrupt(db()) :: :ok | {:error, reason()}
+  def interrupt(_conn), do: :erlang.nif_error(:not_loaded)
+
   @spec execute(db(), String.Chars.t()) :: :ok | {:error, reason()}
   def execute(_conn, _sql), do: :erlang.nif_error(:not_loaded)
 


### PR DESCRIPTION
We encounter the db connection can not be closed when a long-running query gets a timeout(Ecto environment) but the query is still running in the background and takes the CPU resource. For this function, we can manually trigger and force-stop the query. Then we can close and release the resource successfully.

Ref: https://www.sqlite.org/c3ref/interrupt.html