### PR TITLE
Accept a list of modes to open db with nomutex option.

### DIFF
--- a/lib/exqlite/connection.ex
+++ b/lib/exqlite/connection.ex
@@ -58,6 +58,7 @@ defmodule Exqlite.Connection do
 
   @type connection_opt() ::
           {:database, String.t()}
+          | {:mode, :readwrite | :readonly | :readonly_nomutex}
           | {:journal_mode, journal_mode()}
           | {:temp_store, temp_store()}
           | {:synchronous, synchronous()}
@@ -91,7 +92,8 @@ defmodule Exqlite.Connection do
     * `:database` - The path to the database. In memory is allowed. You can use
       `:memory` or `":memory:"` to designate that.
     * `:mode` - use `:readwrite` to open the database for reading and writing
-      or `:readonly` to open it in read-only mode. `:readwrite` will also create
+      , `:readonly` to open it in read-only mode or `:readonly_nomutex` to open
+      it in read-only with nomutex mode. `:readwrite` will also create
       the database if it doesn't already exist. Defaults to `:readwrite`.
     * `:journal_mode` - Sets the journal mode for the sqlite connection. Can be
       one of the following `:delete`, `:truncate`, `:persist`, `:memory`,
@@ -159,8 +161,8 @@ defmodule Exqlite.Connection do
             "./priv/sqlite/\#{arch_dir}/vss0"
           ]
       ```
-    * `:before_disconnect` - A function to run before disconnect, either a 
-      2-arity fun or `{module, function, args}` with the close reason and 
+    * `:before_disconnect` - A function to run before disconnect, either a
+      2-arity fun or `{module, function, args}` with the close reason and
       `t:Exqlite.Connection.t/0` prepended to `args` or `nil` (default: `nil`)
 
   For more information about the options above, see [sqlite documentation][1]

--- a/lib/exqlite/connection.ex
+++ b/lib/exqlite/connection.ex
@@ -58,7 +58,7 @@ defmodule Exqlite.Connection do
 
   @type connection_opt() ::
           {:database, String.t()}
-          | {:mode, :readwrite | :readonly}
+          | {:mode, Sqlite3.open_opt()}
           | {:journal_mode, journal_mode()}
           | {:temp_store, temp_store()}
           | {:synchronous, synchronous()}
@@ -92,8 +92,10 @@ defmodule Exqlite.Connection do
     * `:database` - The path to the database. In memory is allowed. You can use
       `:memory` or `":memory:"` to designate that.
     * `:mode` - use `:readwrite` to open the database for reading and writing
-      or `:readonly` to open it in read-only mode with no mutex. `:readwrite` will also create
+      , `:readonly` to open it in read-only mode or `[:readonly | :readwrite, :nomutex]`
+      to open it with no mutex mode. `:readwrite` will also create
       the database if it doesn't already exist. Defaults to `:readwrite`.
+      Note: [:readwrite, :nomutex] is not recommended.
     * `:journal_mode` - Sets the journal mode for the sqlite connection. Can be
       one of the following `:delete`, `:truncate`, `:persist`, `:memory`,
       `:wal`, or `:off`. Defaults to `:delete`. It is recommended that you use

--- a/lib/exqlite/connection.ex
+++ b/lib/exqlite/connection.ex
@@ -58,7 +58,7 @@ defmodule Exqlite.Connection do
 
   @type connection_opt() ::
           {:database, String.t()}
-          | {:mode, :readwrite | :readonly | :readonly_nomutex}
+          | {:mode, :readwrite | :readonly}
           | {:journal_mode, journal_mode()}
           | {:temp_store, temp_store()}
           | {:synchronous, synchronous()}
@@ -92,8 +92,7 @@ defmodule Exqlite.Connection do
     * `:database` - The path to the database. In memory is allowed. You can use
       `:memory` or `":memory:"` to designate that.
     * `:mode` - use `:readwrite` to open the database for reading and writing
-      , `:readonly` to open it in read-only mode or `:readonly_nomutex` to open
-      it in read-only with nomutex mode. `:readwrite` will also create
+      or `:readonly` to open it in read-only mode with no mutex. `:readwrite` will also create
       the database if it doesn't already exist. Defaults to `:readwrite`.
     * `:journal_mode` - Sets the journal mode for the sqlite connection. Can be
       one of the following `:delete`, `:truncate`, `:persist`, `:memory`,

--- a/lib/exqlite/sqlite3.ex
+++ b/lib/exqlite/sqlite3.ex
@@ -19,7 +19,7 @@ defmodule Exqlite.Sqlite3 do
   @type statement() :: reference()
   @type reason() :: atom() | String.t()
   @type row() :: list()
-  @type open_opt :: {:mode, :readwrite | :readonly | :readonly_nomutex}
+  @type open_opt :: {:mode, :readwrite | :readonly}
 
   @doc """
   Opens a new sqlite database at the Path provided.
@@ -29,7 +29,7 @@ defmodule Exqlite.Sqlite3 do
   ## Options
 
     * `:mode` - use `:readwrite` to open the database for reading and writing
-      , `:readonly` to open it in read-only mode or `:readonly_nomutex` to open it in read-only with nomutex mode. `:readwrite` will also create
+      or `:readonly` to open it in read-only mode with no mutex. `:readwrite` will also create
       the database if it doesn't already exist. Defaults to `:readwrite`.
   """
   @spec open(String.t(), [open_opt()]) :: {:ok, db()} | {:error, reason()}
@@ -42,9 +42,6 @@ defmodule Exqlite.Sqlite3 do
     do: Flags.put_file_open_flags([:sqlite_open_readwrite, :sqlite_open_create])
 
   defp flags_from_mode(:readonly),
-    do: Flags.put_file_open_flags([:sqlite_open_readonly])
-
-  defp flags_from_mode(:readonly_nomutex),
     do: Flags.put_file_open_flags([:sqlite_open_readonly, :sqlite_open_nomutex])
 
   defp flags_from_mode(mode) do

--- a/lib/exqlite/sqlite3.ex
+++ b/lib/exqlite/sqlite3.ex
@@ -19,7 +19,7 @@ defmodule Exqlite.Sqlite3 do
   @type statement() :: reference()
   @type reason() :: atom() | String.t()
   @type row() :: list()
-  @type open_opt :: {:mode, :readwrite | :readonly}
+  @type open_opt :: {:mode, :readwrite | :readonly | :readonly_nomutex}
 
   @doc """
   Opens a new sqlite database at the Path provided.

--- a/lib/exqlite/sqlite3.ex
+++ b/lib/exqlite/sqlite3.ex
@@ -29,7 +29,7 @@ defmodule Exqlite.Sqlite3 do
   ## Options
 
     * `:mode` - use `:readwrite` to open the database for reading and writing
-      or `:readonly` to open it in read-only mode. `:readwrite` will also create
+      , `:readonly` to open it in read-only mode or `:readonly_nomutex` to open it in read-only with nomutex mode. `:readwrite` will also create
       the database if it doesn't already exist. Defaults to `:readwrite`.
   """
   @spec open(String.t(), [open_opt()]) :: {:ok, db()} | {:error, reason()}
@@ -43,6 +43,9 @@ defmodule Exqlite.Sqlite3 do
 
   defp flags_from_mode(:readonly),
     do: Flags.put_file_open_flags([:sqlite_open_readonly])
+
+  defp flags_from_mode(:readonly_nomutex),
+    do: Flags.put_file_open_flags([:sqlite_open_readonly, :sqlite_open_nomutex])
 
   defp flags_from_mode(mode) do
     raise ArgumentError,

--- a/test/exqlite/sqlite3_test.exs
+++ b/test/exqlite/sqlite3_test.exs
@@ -53,7 +53,7 @@ defmodule Exqlite.Sqlite3Test do
                Sqlite3.execute(ro_conn, insert_value_query)
     end
 
-    test "opens a database in sqlite_open_nomutex mode" do
+    test "opens a database in readonly_nomutex mode" do
       # Create database with readwrite connection
       {:ok, path} = Temp.path()
       {:ok, rw_conn} = Sqlite3.open(path)
@@ -64,7 +64,7 @@ defmodule Exqlite.Sqlite3Test do
       insert_value_query = "insert into test (stuff) values ('This is a test')"
       :ok = Sqlite3.execute(rw_conn, insert_value_query)
 
-      # Read from database with a readonly connection
+      # Read from database with a readonly_nomutex connection
       {:ok, ro_conn} = Sqlite3.open(path, mode: :readonly_nomutex)
 
       select_query = "select id, stuff from test order by id asc"
@@ -73,7 +73,7 @@ defmodule Exqlite.Sqlite3Test do
 
       assert [1, "This is a test"] == columns
 
-      # Readonly nomutex  connection cannot insert
+      # Readonly nomutex connection cannot insert
       assert {:error, "attempt to write a readonly database"} ==
                Sqlite3.execute(ro_conn, insert_value_query)
     end

--- a/test/exqlite/sqlite3_test.exs
+++ b/test/exqlite/sqlite3_test.exs
@@ -53,31 +53,6 @@ defmodule Exqlite.Sqlite3Test do
                Sqlite3.execute(ro_conn, insert_value_query)
     end
 
-    test "opens a database in readonly_nomutex mode" do
-      # Create database with readwrite connection
-      {:ok, path} = Temp.path()
-      {:ok, rw_conn} = Sqlite3.open(path)
-
-      create_table_query = "create table test (id integer primary key, stuff text)"
-      :ok = Sqlite3.execute(rw_conn, create_table_query)
-
-      insert_value_query = "insert into test (stuff) values ('This is a test')"
-      :ok = Sqlite3.execute(rw_conn, insert_value_query)
-
-      # Read from database with a readonly_nomutex connection
-      {:ok, ro_conn} = Sqlite3.open(path, mode: :readonly_nomutex)
-
-      select_query = "select id, stuff from test order by id asc"
-      {:ok, statement} = Sqlite3.prepare(ro_conn, select_query)
-      {:row, columns} = Sqlite3.step(ro_conn, statement)
-
-      assert [1, "This is a test"] == columns
-
-      # Readonly nomutex connection cannot insert
-      assert {:error, "attempt to write a readonly database"} ==
-               Sqlite3.execute(ro_conn, insert_value_query)
-    end
-
     test "opens a database with invalid mode" do
       {:ok, path} = Temp.path()
 

--- a/test/exqlite/sqlite3_test.exs
+++ b/test/exqlite/sqlite3_test.exs
@@ -53,6 +53,31 @@ defmodule Exqlite.Sqlite3Test do
                Sqlite3.execute(ro_conn, insert_value_query)
     end
 
+    test "opens a database in sqlite_open_nomutex mode" do
+      # Create database with readwrite connection
+      {:ok, path} = Temp.path()
+      {:ok, rw_conn} = Sqlite3.open(path)
+
+      create_table_query = "create table test (id integer primary key, stuff text)"
+      :ok = Sqlite3.execute(rw_conn, create_table_query)
+
+      insert_value_query = "insert into test (stuff) values ('This is a test')"
+      :ok = Sqlite3.execute(rw_conn, insert_value_query)
+
+      # Read from database with a readonly connection
+      {:ok, ro_conn} = Sqlite3.open(path, mode: :readonly_nomutex)
+
+      select_query = "select id, stuff from test order by id asc"
+      {:ok, statement} = Sqlite3.prepare(ro_conn, select_query)
+      {:row, columns} = Sqlite3.step(ro_conn, statement)
+
+      assert [1, "This is a test"] == columns
+
+      # Readonly nomutex  connection cannot insert
+      assert {:error, "attempt to write a readonly database"} ==
+               Sqlite3.execute(ro_conn, insert_value_query)
+    end
+
     test "opens a database with invalid mode" do
       {:ok, path} = Temp.path()
 


### PR DESCRIPTION
In our use case, we only read the database and never write the data. We found this flag can open db with no mutex. It should be safe to open db as read-only and no mutex.

Ref: https://www.sqlite.org/c3ref/open.html