### PR TITLE
Make tests synchronous

### DIFF
--- a/test/exqlite/connection_test.exs
+++ b/test/exqlite/connection_test.exs
@@ -1,5 +1,5 @@
 defmodule Exqlite.ConnectionTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
 
   alias Exqlite.Connection
   alias Exqlite.Query

--- a/test/exqlite/error_test.exs
+++ b/test/exqlite/error_test.exs
@@ -1,5 +1,5 @@
 defmodule Exqlite.ErrorTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
 
   alias Exqlite.Error
 

--- a/test/exqlite/extensions_test.exs
+++ b/test/exqlite/extensions_test.exs
@@ -1,5 +1,5 @@
 defmodule Exqlite.ExtensionsTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
 
   alias Exqlite.Basic
 

--- a/test/exqlite/integration_test.exs
+++ b/test/exqlite/integration_test.exs
@@ -1,5 +1,5 @@
 defmodule Exqlite.IntegrationTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
 
   alias Exqlite.Connection
   alias Exqlite.Sqlite3

--- a/test/exqlite/pragma_test.exs
+++ b/test/exqlite/pragma_test.exs
@@ -1,5 +1,5 @@
 defmodule Exqlite.PragmaTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
 
   alias Exqlite.Pragma
 

--- a/test/exqlite/query_test.exs
+++ b/test/exqlite/query_test.exs
@@ -1,5 +1,5 @@
 defmodule Exqlite.QueryTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
 
   setup :create_conn!
 

--- a/test/exqlite/timeout_segfault_test.exs
+++ b/test/exqlite/timeout_segfault_test.exs
@@ -1,5 +1,5 @@
 defmodule Exqlite.TimeoutSegfaultTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
 
   @moduletag :slow_test
 


### PR DESCRIPTION
This is an effort to make the Windows CI runner stop being flappy.