### PR TITLE
Make `bind` raise an exception when value fails to bind

### DIFF
--- a/lib/exqlite/bind_error.ex
+++ b/lib/exqlite/bind_error.ex
@@ -1,0 +1,18 @@
+defmodule Exqlite.BindError do
+  @moduledoc """
+  An argument failed to bind.
+  """
+
+  defexception [:message, :argument]
+
+  @type t :: %__MODULE__{
+          message: String.t(),
+          argument: term()
+        }
+
+  @impl true
+  def message(%__MODULE__{message: message, argument: nil}), do: message
+
+  def message(%__MODULE__{message: message, argument: argument}),
+    do: "#{message} #{inspect(argument)}"
+end

--- a/lib/exqlite/sqlite3.ex
+++ b/lib/exqlite/sqlite3.ex
@@ -116,6 +116,17 @@ defmodule Exqlite.Sqlite3 do
   @spec bind(db(), statement(), list()) :: :ok | {:error, reason()}
   def bind(conn, statement, args) do
     Sqlite3NIF.bind(conn, statement, Enum.map(args, &convert/1))
+  rescue
+    err in ErlangError ->
+      case err do
+        %{original: %{message: message, argument: argument}} ->
+          reraise Exqlite.BindError,
+                  [message: message, argument: argument],
+                  __STACKTRACE__
+
+        %{reason: message} ->
+          reraise Exqlite.BindError, [message: message], __STACKTRACE__
+      end
   end
 
   @spec columns(db(), statement()) :: {:ok, [binary()]} | {:error, reason()}

--- a/test/exqlite/sqlite3_test.exs
+++ b/test/exqlite/sqlite3_test.exs
@@ -366,6 +366,19 @@ defmodule Exqlite.Sqlite3Test do
       :ok = Sqlite3.bind(conn, statement, ["this is a test"])
       assert :done == Sqlite3.step(conn, statement)
     end
+
+    test "bind raises an exception" do
+      {:ok, conn} = Sqlite3.open(":memory:")
+
+      :ok =
+        Sqlite3.execute(conn, "create table test (id integer primary key, stuff text)")
+
+      {:ok, statement} = Sqlite3.prepare(conn, "insert into test (stuff) values (?1)")
+
+      assert_raise Exqlite.BindError, fn ->
+        Sqlite3.bind(conn, statement, [%ArgumentError{}])
+      end
+    end
   end
 
   describe ".multi_step/3" do


### PR DESCRIPTION
Rather than return a tuple, it's best to explode and let the caller figure out how to handle a raised exception. We'll provide which argument failed to help with debugging.