### PR TITLE
only compile and upload current target

### DIFF
--- a/.github/workflows/linux-precompile.yml
+++ b/.github/workflows/linux-precompile.yml
@@ -70,7 +70,13 @@ jobs:
           mix elixir_make.precompile
 
       - uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/') && matrix.arch == 'x86_64'
         with:
           files: |
             cache/*.tar.gz
+      
+      - uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/') && matrix.arch != 'x86_64'
+        with:
+          files: |
+            cache/*${{ matrix.arch }}*.tar.gz

--- a/.github/workflows/macos-precompile.yml
+++ b/.github/workflows/macos-precompile.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: macos-14
     env:
       MIX_ENV: prod
+      CC_PRECOMPILER_PRECOMPILE_ONLY_LOCAL: "true"
     strategy:
       matrix:
         arch:


### PR DESCRIPTION
Just noticed that current CI will upload the same precompiled binary for x86_64 a few times, for example, https://github.com/elixir-sqlite/exqlite/actions/runs/11237432761/job/31239865968

```
Run softprops/action-gh-release@v1
⬆️ Uploading exqlite-nif-2.17-aarch64-linux-gnu-0.25.0.tar.gz...
⬆️ Uploading exqlite-nif-2.17-aarch64-linux-musl-0.25.0.tar.gz...
♻️ Deleting previously uploaded asset exqlite-nif-2.17-x86_64-linux-gnu-0.25.0.tar.gz...
⬆️ Uploading exqlite-nif-2.17-x86_64-linux-gnu-0.25.0.tar.gz...
🎉 Release ready at https://github.com/elixir-sqlite/exqlite/releases/tag/v0.25.0
```

And sometimes it might cause trouble in this way.

I'd like to address this issue in `elixir_make` and/or `cc_precompiler`, but sadly I haven't got enough bandwidth at the moment to add one more option/flag and test it properly and thoroughly. This PR should be good enough to do the job until then!