### PR TITLE
Reset stmt when done

### DIFF
--- a/c_src/sqlite3_nif.c
+++ b/c_src/sqlite3_nif.c
@@ -639,6 +639,7 @@ exqlite_multi_step(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
                 return am_busy;
 
             case SQLITE_DONE:
+                sqlite3_reset(statement->statement);
                 return enif_make_tuple2(env, am_done, rows);
 
             case SQLITE_ROW:
@@ -683,10 +684,13 @@ exqlite_step(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
               am_row,
               make_row(env, statement->statement));
         case SQLITE_BUSY:
+            sqlite3_reset(statement->statement);
             return am_busy;
         case SQLITE_DONE:
+            sqlite3_reset(statement->statement);
             return am_done;
         default:
+            sqlite3_reset(statement->statement);
             return make_sqlite3_error_tuple(env, rc, conn->db);
     }
 }

--- a/lib/exqlite/sqlite3.ex
+++ b/lib/exqlite/sqlite3.ex
@@ -177,7 +177,6 @@ defmodule Exqlite.Sqlite3 do
     args_count = length(args)
 
     if args_count == params_count do
-      reset(stmt)
       bind_all(args, stmt, 1)
     else
       raise ArgumentError, "expected #{params_count} arguments, got #{args_count}"


### PR DESCRIPTION
Handles https://github.com/elixir-sqlite/exqlite/pull/298#discussion_r1792822558

> [...] In the future, it should be called once we are done with the statement rather than before using it since otherwise SQLite would be [wasting](https://github.com/python/cpython/issues/89121#issuecomment-1093926075) resources by keeping finished but non-reset statements.

It also improves `bind/2` performance since it doesn't have to go through dirty scheduler for a `reset/1` call anymore.