### PR TITLE
Add insert_all

### DIFF
--- a/c_src/sqlite3_nif.c
+++ b/c_src/sqlite3_nif.c
@@ -695,8 +695,9 @@ static ERL_NIF_TERM
 exqlite_insert_all(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 {
     statement_t* statement;
-    if (!enif_get_resource(env, argv[0], statement_type, (void**)&statement))
+    if (!enif_get_resource(env, argv[0], statement_type, (void**)&statement)) {
         return raise_badarg(env, argv[0]);
+    }
 
     int stmt_param_count = sqlite3_bind_parameter_count(statement->statement);
     int types_array[stmt_param_count];

--- a/c_src/sqlite3_nif.c
+++ b/c_src/sqlite3_nif.c
@@ -728,8 +728,9 @@ exqlite_insert_all(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
         for (unsigned int i = 1; i <= stmt_param_count; i++) {
             ERL_NIF_TERM param;
 
-            if (!enif_get_list_cell(env, head, &param, &head))
+            if (!enif_get_list_cell(env, head, &param, &head)) {
                 return raise_badarg(env, param);
+            }
 
             if (enif_is_identical(param, am_nil)) {
                 rc = sqlite3_bind_null(statement->statement, i);

--- a/c_src/sqlite3_nif.c
+++ b/c_src/sqlite3_nif.c
@@ -785,8 +785,9 @@ exqlite_insert_all(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
         }
 
         rc = sqlite3_step(statement->statement);
-        if (rc != SQLITE_DONE)
+        if (rc != SQLITE_DONE) {
             return make_sqlite3_error_tuple(env, rc, sqlite3_db_handle(statement->statement));
+        }
 
         rows = tail;
     }

--- a/c_src/sqlite3_nif.c
+++ b/c_src/sqlite3_nif.c
@@ -738,8 +738,9 @@ exqlite_insert_all(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
                 switch (types_array[i - 1]) {
                     case SQLITE_INTEGER: {
                         ErlNifSInt64 i64;
-                        if (!enif_get_int64(env, param, &i64))
+                        if (!enif_get_int64(env, param, &i64)) {
                             return raise_badarg(env, param);
+                        }
 
                         rc = sqlite3_bind_int64(statement->statement, i, i64);
                         break;

--- a/c_src/sqlite3_nif.c
+++ b/c_src/sqlite3_nif.c
@@ -728,7 +728,7 @@ exqlite_insert_all(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
         sqlite3_reset(statement->statement);
 
         // bind row
-        for (unsigned int i = 1; i <= stmt_param_count; i++) {
+        for (int i = 1; i <= stmt_param_count; i++) {
             ERL_NIF_TERM param;
 
             if (!enif_get_list_cell(env, head, &param, &head)) {

--- a/c_src/sqlite3_nif.c
+++ b/c_src/sqlite3_nif.c
@@ -779,8 +779,9 @@ exqlite_insert_all(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
                 }
             }
 
-            if (rc != SQLITE_OK)
+            if (rc != SQLITE_OK) {
                 return make_sqlite3_error_tuple(env, rc, sqlite3_db_handle(statement->statement));
+            }
         }
 
         rc = sqlite3_step(statement->statement);

--- a/c_src/sqlite3_nif.c
+++ b/c_src/sqlite3_nif.c
@@ -713,8 +713,9 @@ exqlite_insert_all(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
         }
 
         int type;
-        if (!enif_get_int(env, head, &type))
+        if (!enif_get_int(env, head, &type)) {
             return raise_badarg(env, types);
+        }
 
         types_array[i] = type;
         types          = tail;

--- a/c_src/sqlite3_nif.c
+++ b/c_src/sqlite3_nif.c
@@ -758,8 +758,9 @@ exqlite_insert_all(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 
                     case SQLITE_TEXT: {
                         ErlNifBinary text;
-                        if (!enif_inspect_binary(env, param, &text))
+                        if (!enif_inspect_binary(env, param, &text)) {
                             return raise_badarg(env, param);
+                        }
 
                         rc = sqlite3_bind_text(statement->statement, i, (char*)text.data, text.size, SQLITE_TRANSIENT);
                         break;

--- a/c_src/sqlite3_nif.c
+++ b/c_src/sqlite3_nif.c
@@ -748,8 +748,9 @@ exqlite_insert_all(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 
                     case SQLITE_FLOAT: {
                         double f64;
-                        if (!enif_get_double(env, param, &f64))
+                        if (!enif_get_double(env, param, &f64)) {
                             return raise_badarg(env, param);
+                        }
 
                         rc = sqlite3_bind_double(statement->statement, i, f64);
                         break;

--- a/c_src/sqlite3_nif.c
+++ b/c_src/sqlite3_nif.c
@@ -707,7 +707,7 @@ exqlite_insert_all(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
     ERL_NIF_TERM head, tail;
 
     // process types
-    for (unsigned int i = 0; i < stmt_param_count; i++) {
+    for (int i = 0; i < stmt_param_count; i++) {
         if (!enif_get_list_cell(env, types, &head, &tail)) {
             return raise_badarg(env, types);
         }

--- a/c_src/sqlite3_nif.c
+++ b/c_src/sqlite3_nif.c
@@ -703,7 +703,7 @@ exqlite_insert_all(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 
     // TODO: MSVC can't do VLA
     // int types_array[stmt_param_count];
-    int* types_array = (int*)malloc(stmt_param_count * sizeof(int));
+    int* types_array = (int*)enif_alloc(stmt_param_count * sizeof(int));
 
     if (!types_array) {
         return make_error_tuple(env, am_out_of_memory);
@@ -801,7 +801,7 @@ exqlite_insert_all(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
         rows = tail;
     }
 
-    free(types_array);
+    enif_free(types_array);
     return am_done;
 }
 

--- a/c_src/sqlite3_nif.c
+++ b/c_src/sqlite3_nif.c
@@ -708,8 +708,9 @@ exqlite_insert_all(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 
     // process types
     for (unsigned int i = 0; i < stmt_param_count; i++) {
-        if (!enif_get_list_cell(env, types, &head, &tail))
+        if (!enif_get_list_cell(env, types, &head, &tail)) {
             return raise_badarg(env, types);
+        }
 
         int type;
         if (!enif_get_int(env, head, &type))

--- a/c_src/sqlite3_nif.c
+++ b/c_src/sqlite3_nif.c
@@ -768,8 +768,9 @@ exqlite_insert_all(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 
                     case SQLITE_BLOB: {
                         ErlNifBinary blob;
-                        if (!enif_inspect_binary(env, param, &blob))
+                        if (!enif_inspect_binary(env, param, &blob)) {
                             return raise_badarg(env, param);
+                        }
 
                         rc = sqlite3_bind_blob(statement->statement, i, (char*)blob.data, blob.size, SQLITE_TRANSIENT);
                         break;

--- a/c_src/sqlite3_nif.c
+++ b/c_src/sqlite3_nif.c
@@ -698,7 +698,7 @@ exqlite_insert_all(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
     if (!enif_get_resource(env, argv[0], statement_type, (void**)&statement))
         return raise_badarg(env, argv[0]);
 
-    int stmt_param_count = (unsigned int)sqlite3_bind_parameter_count(statement->statement);
+    int stmt_param_count = sqlite3_bind_parameter_count(statement->statement);
     int types_array[stmt_param_count];
 
     ERL_NIF_TERM types = argv[1];

--- a/c_src/sqlite3_nif.c
+++ b/c_src/sqlite3_nif.c
@@ -700,7 +700,14 @@ exqlite_insert_all(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
     }
 
     int stmt_param_count = sqlite3_bind_parameter_count(statement->statement);
-    int types_array[stmt_param_count];
+
+    // TODO: MSVC can't do VLA
+    // int types_array[stmt_param_count];
+    int* types_array = (int*)malloc(stmt_param_count * sizeof(int));
+
+    if (!types_array) {
+        return make_error_tuple(env, am_out_of_memory);
+    }
 
     ERL_NIF_TERM types = argv[1];
     ERL_NIF_TERM rows  = argv[2];
@@ -794,6 +801,7 @@ exqlite_insert_all(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
         rows = tail;
     }
 
+    free(types_array);
     return am_done;
 }
 

--- a/lib/exqlite/sqlite3.ex
+++ b/lib/exqlite/sqlite3.ex
@@ -280,6 +280,9 @@ defmodule Exqlite.Sqlite3 do
   @doc """
   Bulk-inserts rows into a prepared statement. Must be called inside a transaction.
 
+  The `types` parameter is type of each column in the order they are specified 
+  in the parameter `rows`. For example, `[["a", 1, 1.0]]` would have `types`
+  specified as `[:text, :integer, :float]`.
       iex> {:ok, conn} = Sqlite3.open(":memory:", [:readonly])
       iex> :ok = Sqlite3.execute(conn, "CREATE TABLE users (name TEXT)")
       iex> {:ok, insert} = Sqlite3.prepare(conn, "INSERT INTO users (name) VALUES (?)")

--- a/lib/exqlite/sqlite3.ex
+++ b/lib/exqlite/sqlite3.ex
@@ -283,6 +283,7 @@ defmodule Exqlite.Sqlite3 do
   The `types` parameter is type of each column in the order they are specified 
   in the parameter `rows`. For example, `[["a", 1, 1.0]]` would have `types`
   specified as `[:text, :integer, :float]`.
+
       iex> {:ok, conn} = Sqlite3.open(":memory:", [:readonly])
       iex> :ok = Sqlite3.execute(conn, "CREATE TABLE users (name TEXT)")
       iex> {:ok, insert} = Sqlite3.prepare(conn, "INSERT INTO users (name) VALUES (?)")

--- a/lib/exqlite/sqlite3_nif.ex
+++ b/lib/exqlite/sqlite3_nif.ex
@@ -69,6 +69,9 @@ defmodule Exqlite.Sqlite3NIF do
   @spec set_log_hook(pid()) :: :ok | {:error, reason()}
   def set_log_hook(_pid), do: :erlang.nif_error(:not_loaded)
 
+  @spec insert_all(statement, [integer], [row]) :: :done | {:error, reason()}
+  def insert_all(_stmt, _types, _rpws), do: :erlang.nif_error(:not_loaded)
+
   @spec bind_parameter_count(statement) :: integer
   def bind_parameter_count(_stmt), do: :erlang.nif_error(:not_loaded)
 


### PR DESCRIPTION
This PR adds a helper NIF that can be used to bulk-insert "unlimited" number of rows.

Should be enough to clоse https://github.com/elixir-sqlite/exqlite/issues/129 once it gets into `ecto_sqlite3`

Regarding [performance:](https://github.com/elixir-sqlite/exqlite/issues/129#issuecomment-937400559) XQLite uses this approach in `insert_all` benchmark in https://github.com/ruslandoga/elixir-sqlite-bench