### PR TITLE
force build in dev and test envs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -12,7 +12,7 @@ defmodule Exqlite.MixProject do
       compilers: [:elixir_make] ++ Mix.compilers(),
       make_targets: ["all"],
       make_clean: ["clean"],
-      make_force_build: Application.get_env(:exqlite, :force_build, false),
+      make_force_build: make_force_build(Mix.env()),
       make_precompiler: make_precompiler(),
       make_precompiler_url:
         "https://github.com/elixir-sqlite/exqlite/releases/download/v#{@version}/@{artefact_filename}",
@@ -77,6 +77,12 @@ defmodule Exqlite.MixProject do
     else
       {:nif, CCPrecompiler}
     end
+  end
+
+  defp make_force_build(env) when env in [:dev, :test], do: true
+
+  defp make_force_build(_env) do
+    Application.get_env(:exqlite, :force_build, false)
   end
 
   defp package do


### PR DESCRIPTION
Context: https://github.com/elixir-sqlite/exqlite/pull/306#discussion_r1845293400

I wonder if this would also force builds in dev / test downstream? The desired outcome is to only force builds while working on Exqlite itself.