### PR TITLE
The module_str parameter of open_resource_type has to be NULL

### DIFF
--- a/c_src/sqlite3_nif.c
+++ b/c_src/sqlite3_nif.c
@@ -990,7 +990,7 @@ on_load(ErlNifEnv* env, void** priv, ERL_NIF_TERM info)
 
     connection_type = enif_open_resource_type(
       env,
-      "exqlite",
+      NULL,
       "connection_type",
       connection_type_destructor,
       ERL_NIF_RT_CREATE,
@@ -1001,7 +1001,7 @@ on_load(ErlNifEnv* env, void** priv, ERL_NIF_TERM info)
 
     statement_type = enif_open_resource_type(
       env,
-      "exqlite",
+      NULL,
       "statement_type",
       statement_type_destructor,
       ERL_NIF_RT_CREATE,


### PR DESCRIPTION
As documented in https://www.erlang.org/doc/apps/erts/erl_nif#enif_open_resource_type.

This only leads to problems in debug builds as the value is currently guarded by an assertion.