### PR TITLE
Protect critical sections better with mutexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.29.0
+
+- changed: Add more mutex locking around critical sections working with the
+  sqlite database.
+
 ## v0.28.0
 
 - changed: Update sqlite to `3.48.0`.

--- a/c_src/sqlite3_nif.c
+++ b/c_src/sqlite3_nif.c
@@ -331,9 +331,9 @@ exqlite_execute(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 
     rc = sqlite3_exec(conn->db, (char*)bin.data, NULL, NULL, NULL);
     if (rc != SQLITE_OK) {
+        ERL_NIF_TERM result = make_sqlite3_error_tuple(env, rc, conn->db);
         enif_mutex_unlock(conn->mutex);
-
-        return make_sqlite3_error_tuple(env, rc, conn->db);
+        return result;
     }
 
     enif_mutex_unlock(conn->mutex);


### PR DESCRIPTION
As this integration has grown, we need to be careful about what is and is not protected. All calls exposed through the NIF that interact with a statement or connection, need to acquire a mutex lock before operating on the database. Nested helper function calls should refrain from locking anything, otherwise we'll wind up with a deadlock.

@ruslandoga this will probably have some conflicts with any work you are doing.