### PR TITLE
add SunOS to *BSD flags case

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ else
 		LDFLAGS += -fPIC -shared
 		LIB_NAME = $(PREFIX)/sqlite3_nif.dll
 	endif
-	ifeq ($(KERNEL_NAME), $(filter $(KERNEL_NAME),OpenBSD FreeBSD NetBSD))
+	ifeq ($(KERNEL_NAME), $(filter $(KERNEL_NAME),OpenBSD FreeBSD NetBSD SunOS))
 		CFLAGS += -fPIC
 		LDFLAGS += -fPIC -shared
 	endif


### PR DESCRIPTION
Slight change to get the .so building on OmniOS CE r151054 x86_64. It should work on OpenIndiana, SmartOS, other illumos distros that report `SunOS` from `uname -s` (helios?)

The NIF is working in my application so far, both with the system `sqlite-3` pkg and without. However, to get the tests in this project to pass, I had to make changes to:

* https://github.com/mindreframer/ex_sqlean/compare/main...kenichi:ex_sqlean:sunos
* https://github.com/mindreframer/sqlean (unpushed, curious about diffs w/ upstream)

I had to allow the test script in sqlean (fork) to update expectations, then it passed. With the .so files built and those other changes all reflected locally:

```
Running ExUnit with seed: 614009, max_cases: 8
Excluding tags: [:slow_test]

...............................................................................................................................
Finished in 5.9 seconds (0.00s async, 5.9s sync)
11 doctests, 117 tests, 0 failures, 1 excluded
```