### PR TITLE
docs: update VSCode terminal configuration for Windows users

### DIFF
--- a/guides/windows.md
+++ b/guides/windows.md
@@ -56,8 +56,7 @@ cmd /k "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxili
 
 ## Visual Studio Code users using ElixirLS
 
-> Assuming you have _latest_ version of Build Tools, aligned with Visual Studio **2022**,  
-installed in its default installation path.
+> Assuming you have _latest_ version of Build Tools, aligned with Visual Studio **2022**.
 
 Start Visual Studio Code from a PowerShell prompt within your project folder.
 
@@ -76,10 +75,45 @@ Within your global `settings.json` or your workspace `.vscode\settings.json` add
 
 ```json
 {
-  "terminal.integrated.shell.windows": "cmd.exe",
-  "terminal.integrated.shellArgs.windows": [
-     "/k",
-     "C:\\Program Files (x86)\\Microsoft Visual Studio\\2022\\BuildTools\\VC\\Auxiliary\\Build\\vcvars64.bat"
-  ]
+    "terminal.integrated.defaultProfile.windows": "PowerShell for VS2022",
+    // You can select one you like.
+    "terminal.integrated.profiles.windows": {
+        "Command Prompt for VS2022": {
+            "path": [
+                "${env:windir}\\Sysnative\\cmd.exe",
+                "${env:windir}\\System32\\cmd.exe"
+            ],
+            "args": [
+                // Please note that you need to change the directory to YOURS and translate the backslashes(`\` => `\\`).
+                "/k","D:\\VisualStudio\\VS2022\\Community\\Common7\\Tools\\VsDevCmd.bat",
+                "-startdir=none",
+                "-arch=x64",
+                "-host_arch=x64"
+                // In you have not installed whole VisualStudio, only use
+                // "D:\\VisualStudio\\VS2022\\Community\\VC\\Auxiliary\\Build\\vcvars64.bat"
+                // or some directory you installed is better.
+            ],
+            "icon": "terminal-cmd"
+        },
+        "PowerShell for VS2022": {
+            "source": "PowerShell",
+            "args": [
+                "-NoExit",
+                "-Command",
+                // Don't forget let `"""` into `\"` in module part during copy.
+                "&{Import-Module \"D:\\VisualStudio\\VS2022\\Community\\Common7\\Tools\\Microsoft.VisualStudio.DevShell.dll\"; Enter-VsDevShell e182031c -SkipAutomaticLocation -DevCmdArguments \"-arch=x64 -host_arch=x64\"}"
+            ],
+            "icon": "terminal-powershell",
+            "env": {}
+        }
+    }
 }
 ```
+
+> **How arguments come?**
+>
+> If you have Windows Terminal, after VS2022 installed, your Windows Terminal app should include `Developer Command Prompt for VS2022` and `Developer PowerShell for VS2022`.
+>
+> Next you just need to switch to "Configuration" and scroll down to "Profiles" and choose the one you prefer.
+>
+> After copy and paste, simply do like `~w()` sigil does in `args` part above, replacing the paths with your actual Visual Studio installation directory.


### PR DESCRIPTION
Currently, Visual Studio Code's `terminal.integrated.shell.*` and `terminal.integrated.shellArgs.*` are deprecated.

So I tried `terminal.integrated.profiles.windows` to replace source configurations, and I found that it can still run normally if it is not installed in the default directory (the specific situation has not been studied in depth).

Compiles fine,

<img width="1835" height="725" alt="image" src="https://github.com/user-attachments/assets/41d82a1c-33fd-4587-96bb-0d98bfbed793" />

and ElixirLS works well.

<details>
<summary>Output from ElixirLS</summary>

```
Installing ElixirLS release v0.29.3
Running in d:/CodeRepo/ForkLibs/exqlite
Install complete
[Info  - 18:16:58] Started ElixirLS v0.29.3
[Info  - 18:16:58] Running in d:/CodeRepo/ForkLibs/exqlite
[Info  - 18:16:58] ElixirLS built with elixir 1.18.4 on OTP 28
[Info  - 18:16:58] Running on elixir 1.18.4 (compiled with Erlang/OTP 25) on OTP 28
[Info  - 18:16:58] Protocols are not consolidated
[Info  - 18:16:58] Elixir sources not found (checking in d:/home/build/elixir). Code navigation to Elixir modules disabled.
[Info  - 18:16:59] Received client configuration via workspace/configuration
%{"additionalWatchedExtensions" => [], "autoBuild" => true, "autoInsertRequiredAlias" => true, "dialyzerEnabled" => true, "dialyzerFormat" => "dialyxir_long", "dialyzerWarnOpts" => ["no_opaque"], "dotFormatter" => "", "enableTestLenses" => false, "envVariables" => %{}, "fetchDeps" => false, "incrementalDialyzer" => true, "languageServerOverridePath" => "", "mcpEnabled" => false, "mcpPort" => 0, "mixEnv" => "test", "mixTarget" => "", "projectDir" => "", "signatureAfterComplete" => true, "stdlibSrcDir" => "", "suggestSpecs" => true, "trace" => %{"server" => "off"}, "useCurrentRootFolderAsProjectDir" => false}
[Info  - 18:16:59] Registering for workspace/didChangeConfiguration notifications
[Info  - 18:16:59] Starting build with MIX_ENV: test MIX_TARGET: host
[Info  - 18:16:59] client/registerCapability succeeded
[Info  - 18:16:59] Registering for workspace/didChangeWatchedFiles notifications
[Info  - 18:16:59] client/registerCapability succeeded
==> file_system
Compiling 7 files (.ex)
Generated file_system app
==> temp
Compiling 3 files (.ex)
Generated temp app
==> bunt
Compiling 2 files (.ex)
Generated bunt app
==> jason
Compiling 10 files (.ex)
Generated jason app
==> erlex
Compiling 2 files (.erl)
Compiling 1 file (.ex)
Generated erlex app
==> elixir_make
Compiling 8 files (.ex)
Generated elixir_make app
==> table
Compiling 5 files (.ex)
Generated table app
==> exqlite
===> Analyzing applications...
===> Compiling telemetry
==> db_connection
Compiling 17 files (.ex)
Generated db_connection app
==> ex_sqlean
Compiling 5 files (.ex)
Generated ex_sqlean app
==> dialyxir
Compiling 64 files (.ex)
[Warn  - 18:17:06]     warning: using single-quoted strings to represent charlists is deprecated.
    Use ~c"" if you indeed want a charlist or use "" instead.
    You may run "mix format --migrate" to change all single-quoted
    strings to use the ~c sigil and fix this warning.
    │
 66 │     app_file = Atom.to_charlist(app) ++ '.app'
    │                                         ~
    │
    └─ lib/dialyxir/plt.ex:66:41

[Warn  - 18:17:06]      warning: using single-quoted strings to represent charlists is deprecated.
     Use ~c"" if you indeed want a charlist or use "" instead.
     You may run "mix format --migrate" to change all single-quoted
     strings to use the ~c sigil and fix this warning.
     │
 114 │     beam = Atom.to_charlist(module) ++ '.beam'
     │                                        ~
     │
     └─ lib/dialyxir/plt.ex:114:40

[Warn  - 18:17:06]     warning: redefining module Mix.Tasks.Dialyzer.Explain (current version loaded from c:/Users/Q/AppData/Local/mix/Cache/installs/elixir-1.18.4-erts-16.1/f9225761234baa3c99f3611b93984b73/_build/prod/lib/dialyxir_vendored/ebin/Elixir.Mix.Tasks.Dialyzer.Explain.beam)
    │
  1 │ defmodule Mix.Tasks.Dialyzer.Explain do
    │ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    │
    └─ lib/mix/tasks/dialyzer/explain.ex:1: Mix.Tasks.Dialyzer.Explain (module)

[Warn  - 18:17:06]     warning: redefining module Mix.Tasks.Dialyzer (current version loaded from c:/Users/Q/AppData/Local/mix/Cache/installs/elixir-1.18.4-erts-16.1/f9225761234baa3c99f3611b93984b73/_build/prod/lib/dialyxir_vendored/ebin/Elixir.Mix.Tasks.Dialyzer.beam)
    │
  1 │ defmodule Mix.Tasks.Dialyzer do
    │ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    │
    └─ lib/mix/tasks/dialyzer.ex:1: Mix.Tasks.Dialyzer (module)

[Warn  - 18:17:06]      warning: redefining module Mix.Tasks.Dialyzer.Build (current version loaded from c:/Users/Q/AppData/Local/mix/Cache/installs/elixir-1.18.4-erts-16.1/f9225761234baa3c99f3611b93984b73/_build/prod/lib/dialyxir_vendored/ebin/Elixir.Mix.Tasks.Dialyzer.Build.beam)
     │
 102 │   defmodule Build do
     │   ~~~~~~~~~~~~~~~~~~
     │
     └─ lib/mix/tasks/dialyzer.ex:102: Mix.Tasks.Dialyzer.Build (module)

[Warn  - 18:17:06]      warning: redefining module Mix.Tasks.Dialyzer.Clean (current version loaded from c:/Users/Q/AppData/Local/mix/Cache/installs/elixir-1.18.4-erts-16.1/f9225761234baa3c99f3611b93984b73/_build/prod/lib/dialyxir_vendored/ebin/Elixir.Mix.Tasks.Dialyzer.Clean.beam)
     │
 120 │   defmodule Clean do
     │   ~~~~~~~~~~~~~~~~~~
     │
     └─ lib/mix/tasks/dialyzer.ex:120: Mix.Tasks.Dialyzer.Clean (module)

Generated dialyxir app
==> credo
Compiling 251 files (.ex)
Generated credo app
==> cc_precompiler
Compiling 3 files (.ex)
Generated cc_precompiler app
==> exqlite
Compiling 12 files (.ex)
Generated exqlite app
[Info  - 18:17:15] Compile took 16148 milliseconds
[Info  - 18:17:15] [ElixirLS WorkspaceSymbols] Indexing...
[Info  - 18:17:15] [ElixirLS WorkspaceSymbols] Module discovery complete
[Info  - 18:17:15] [ElixirLS WorkspaceSymbols] 174 symbols added to index in 17ms
[Info  - 18:17:15] Updating incremental PLT
[Info  - 18:18:28] Dialyzer analysis is up to date
[Info  - 18:18:31] Success typings computed in 2751ms
```
</details>

<details>
<summary>And here's my own configuration</summary>

```
{
    "elixirLS.dialyzerWarnOpts": ["no_opaque"],
    "elixirLS.fetchDeps": false,
    "terminal.integrated.defaultProfile.windows": "PowerShell for VS",
    "terminal.integrated.profiles.windows": {
        "Command Prompt for VS": {
            "path": [
                "${env:windir}\\Sysnative\\cmd.exe",
                "${env:windir}\\System32\\cmd.exe"
            ],
            "args": [
                "/k","D:\\VisualStudio\\VS2022\\Community\\Common7\\Tools\\VsDevCmd.bat",
                "-startdir=none",
                "-arch=x64",
                "-host_arch=x64"],
            "icon": "terminal-cmd"
        },
        "Git Bash": {
            "source": "Git Bash"
        },
        "PowerShell for VS": {
            "source": "PowerShell",
            "args": [
                "-NoExit",
                "-Command",
                "&{Import-Module \"D:\\VisualStudio\\VS2022\\Community\\Common7\\Tools\\Microsoft.VisualStudio.DevShell.dll\"; Enter-VsDevShell e182031c -SkipAutomaticLocation -DevCmdArguments \"-arch=x64 -host_arch=x64\"}"
            ],
            "icon": "terminal-powershell",
            "env": {}
        }
    }
}
```
</details>
