### PR TITLE
Do not force journal mode unless specified

### DIFF
--- a/lib/exqlite/connection.ex
+++ b/lib/exqlite/connection.ex
@@ -464,7 +464,7 @@ defmodule Exqlite.Connection do
   end
 
   defp set_journal_mode(db, options) do
-    maybe_set_pragma(db, "journal_mode", Pragma.journal_mode(options))
+    set_pragma_if_present(db, "journal_mode", Keyword.get(options, :journal_mode))
   end
 
   defp set_temp_store(db, options) do

--- a/test/exqlite/connection_test.exs
+++ b/test/exqlite/connection_test.exs
@@ -171,6 +171,18 @@ defmodule Exqlite.ConnectionTest do
       assert {:error, "attempt to write a readonly database"} ==
                Sqlite3.execute(ro_state.db, insert_value_query)
     end
+
+    test "preserves WAL mode across connections" do
+      path = Temp.path!()
+
+      {:ok, state1} = Connection.connect(database: path, journal_mode: :wal)
+      assert {:ok, "wal"} = get_pragma(state1.db, :journal_mode)
+
+      {:ok, state2} = Connection.connect(database: path)
+      assert {:ok, "wal"} = get_pragma(state2.db, :journal_mode)
+
+      File.rm(path)
+    end
   end
 
   defp get_pragma(db, pragma_name) do


### PR DESCRIPTION
Let SQLite use the default journal mode if none is given. This is important because the database may be in WAL mode already (which is persistent) and forcing it to DELETE mode unexpectedly changes the database out of WAL mode (also in a persistent way).

Closes #340.