### PR TITLE
Fix deadlock when canceling queries stuck in VDBE or busy handler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,10 @@ endif
 
 $(BUILD)/%.o: c_src/%.c
 	@echo " CC $(notdir $@)"
-	$(CC) -c $(ERL_CFLAGS) $(CFLAGS) -o $@ $<
+	$(CC) -c $(ERL_CFLAGS) $(CFLAGS) -MMD -MP -o $@ $<
+
+# Include dependency files for automatic header tracking
+-include $(OBJ:.o=.d)
 
 $(LIB_NAME): $(OBJ)
 	@echo " LD $(notdir $@)"
@@ -152,7 +155,7 @@ $(PREFIX) $(BUILD):
 	mkdir -p $@
 
 clean:
-	$(RM) $(LIB_NAME) $(ARCHIVE_NAME) $(OBJ)
+	$(RM) $(LIB_NAME) $(ARCHIVE_NAME) $(OBJ) $(OBJ:.o=.d)
 
 .PHONY: all clean
 

--- a/c_src/sqlite3_nif.c
+++ b/c_src/sqlite3_nif.c
@@ -479,7 +479,7 @@ exqlite_busy_handler(void* arg, int count)
 
     // Wait on the condvar — can be woken early by cancel()
     tw_lock(&conn->cancel_tw);
-    int cancelled = conn->cancelled;
+    cancelled = conn->cancelled;
     if (!cancelled) {
         tw_wait_ms(&conn->cancel_tw, sleep_ms);
         cancelled = conn->cancelled; // snapshot again after waking

--- a/c_src/sqlite3_nif.c
+++ b/c_src/sqlite3_nif.c
@@ -61,7 +61,7 @@ typedef struct connection
     int authorizer_deny[AUTHORIZER_DENY_SIZE];
 
     // Custom busy handler state
-    volatile int cancelled; // guarded by interrupt_mutex
+    int cancelled; // guarded by interrupt_mutex
     int busy_timeout_ms;
     int progress_handler_steps;
     ErlNifEnv* callback_env; // for enif_is_process_alive

--- a/c_src/sqlite3_nif.c
+++ b/c_src/sqlite3_nif.c
@@ -10,118 +10,6 @@
 #include <erl_nif.h>
 #include <sqlite3.h>
 
-// Platform timed-wait abstraction
-//
-// OTP doesn't provide enif_cond_timedwait, so we wrap pthread_cond_timedwait
-// (POSIX) and SleepConditionVariableCS (Windows). BEAM has two threading
-// backends (pthreads and Win32), so #ifdef _WIN32 covers all platforms.
-
-#ifdef _WIN32
-    #include <windows.h>
-
-typedef struct
-{
-    CRITICAL_SECTION cs;
-    CONDITION_VARIABLE cv;
-} timed_wait_t;
-
-static void
-tw_init(timed_wait_t* tw)
-{
-    InitializeCriticalSection(&tw->cs);
-    InitializeConditionVariable(&tw->cv);
-}
-
-static void
-tw_destroy(timed_wait_t* tw)
-{
-    DeleteCriticalSection(&tw->cs);
-    // Windows CONDITION_VARIABLE has no destroy function
-}
-
-static void
-tw_lock(timed_wait_t* tw)
-{
-    EnterCriticalSection(&tw->cs);
-}
-static void
-tw_unlock(timed_wait_t* tw)
-{
-    LeaveCriticalSection(&tw->cs);
-}
-
-// Returns 0 if signalled, 1 if timed out
-static int
-tw_wait_ms(timed_wait_t* tw, int ms)
-{
-    return SleepConditionVariableCS(&tw->cv, &tw->cs, (DWORD)ms) ? 0 : 1;
-}
-
-static void
-tw_signal(timed_wait_t* tw)
-{
-    WakeConditionVariable(&tw->cv);
-}
-
-#else /* POSIX */
-    #include <pthread.h>
-    #include <time.h>
-    #include <errno.h>
-
-typedef struct
-{
-    pthread_mutex_t mtx;
-    pthread_cond_t cond;
-} timed_wait_t;
-
-static void
-tw_init(timed_wait_t* tw)
-{
-    pthread_mutex_init(&tw->mtx, NULL);
-    // CLOCK_REALTIME: macOS doesn't support CLOCK_MONOTONIC for condvars
-    pthread_cond_init(&tw->cond, NULL);
-}
-
-static void
-tw_destroy(timed_wait_t* tw)
-{
-    pthread_cond_destroy(&tw->cond);
-    pthread_mutex_destroy(&tw->mtx);
-}
-
-static void
-tw_lock(timed_wait_t* tw)
-{
-    pthread_mutex_lock(&tw->mtx);
-}
-static void
-tw_unlock(timed_wait_t* tw)
-{
-    pthread_mutex_unlock(&tw->mtx);
-}
-
-// Returns 0 if signalled, 1 if timed out
-static int
-tw_wait_ms(timed_wait_t* tw, int ms)
-{
-    struct timespec ts;
-    clock_gettime(CLOCK_REALTIME, &ts);
-    ts.tv_sec += ms / 1000;
-    ts.tv_nsec += (ms % 1000) * 1000000L;
-    if (ts.tv_nsec >= 1000000000L) {
-        ts.tv_sec += 1;
-        ts.tv_nsec -= 1000000000L;
-    }
-    return pthread_cond_timedwait(&tw->cond, &tw->mtx, &ts) == ETIMEDOUT ? 1 : 0;
-}
-
-static void
-tw_signal(timed_wait_t* tw)
-{
-    pthread_cond_signal(&tw->cond);
-}
-
-#endif /* _WIN32 */
 
 static ERL_NIF_TERM am_ok;
 static ERL_NIF_TERM am_error;
@@ -174,7 +62,6 @@ typedef struct connection
     int authorizer_deny[AUTHORIZER_DENY_SIZE];
 
     // Custom busy handler state
-    timed_wait_t cancel_tw;
     volatile int cancelled; // volatile for MSVC compat
     int busy_timeout_ms;
     ErlNifEnv* callback_env; // for enif_is_process_alive
@@ -429,69 +316,39 @@ exqlite_busy_handler(void* arg, int count)
 {
     connection_t* conn = (connection_t*)arg;
 
-    // Snapshot cancel state and timeout with lock held
-    tw_lock(&conn->cancel_tw);
-    int cancelled  = conn->cancelled;
-    int timeout_ms = conn->busy_timeout_ms;
+    if (conn->cancelled)
+        return 0;
 
     // Check if the calling process is still alive
-    if (!cancelled && conn->callback_env != NULL &&
+    if (conn->callback_env != NULL &&
         !enif_is_process_alive(conn->callback_env, &conn->caller_pid)) {
         conn->cancelled = 1;
-        cancelled       = 1;
-    }
-    tw_unlock(&conn->cancel_tw);
-
-    // Check if already cancelled
-    if (cancelled) {
-        return 0; // stop retrying → SQLite returns SQLITE_BUSY
-    }
-
-    // No timeout → fail immediately
-    if (timeout_ms <= 0) {
         return 0;
     }
 
-    // Calculate how much time we've already waited.
-    // Use the same delay schedule as SQLite's default busy handler
-    // for the first few retries, then 50ms waits after that.
+    if (conn->busy_timeout_ms <= 0)
+        return 0;
+
     static const int delays[] = {1, 2, 5, 10, 15, 20, 25, 25, 25, 50, 50};
-    static const int ndelay   = sizeof(delays) / sizeof(delays[0]);
+    static const int ndelay = sizeof(delays) / sizeof(delays[0]);
 
     int total_waited = 0;
-    for (int i = 0; i < count && i < ndelay; i++) {
+    for (int i = 0; i < count && i < ndelay; i++)
         total_waited += delays[i];
-    }
-    if (count >= ndelay) {
+    if (count >= ndelay)
         total_waited += (count - ndelay) * 50;
-    }
 
-    if (total_waited >= timeout_ms) {
-        return 0; // timeout exceeded
-    }
-
-    // Calculate sleep duration for this iteration
-    int sleep_ms  = (count < ndelay) ? delays[count] : 50;
-    int remaining = timeout_ms - total_waited;
-    if (sleep_ms > remaining) {
-        sleep_ms = remaining;
-    }
-
-    // Wait on the condvar — can be woken early by cancel()
-    tw_lock(&conn->cancel_tw);
-    cancelled = conn->cancelled;
-    if (!cancelled) {
-        tw_wait_ms(&conn->cancel_tw, sleep_ms);
-        cancelled = conn->cancelled; // snapshot again after waking
-    }
-    tw_unlock(&conn->cancel_tw);
-
-    // After waking, use the snapshot to avoid data race
-    if (cancelled) {
+    if (total_waited >= conn->busy_timeout_ms)
         return 0;
-    }
 
-    return 1; // retry the operation
+    int sleep_ms = (count < ndelay) ? delays[count] : 50;
+    int remaining = conn->busy_timeout_ms - total_waited;
+    if (sleep_ms > remaining)
+        sleep_ms = remaining;
+
+    sqlite3_sleep(sleep_ms);
+
+    return conn->cancelled ? 0 : 1;
 }
 
 // Progress handler: fires every N VDBE opcodes.
@@ -500,10 +357,7 @@ static int
 exqlite_progress_handler(void* arg)
 {
     connection_t* conn = (connection_t*)arg;
-    tw_lock(&conn->cancel_tw);
-    int cancelled = conn->cancelled;
-    tw_unlock(&conn->cancel_tw);
-    return cancelled ? 1 : 0;
+    return conn->cancelled ? 1 : 0;
 }
 
 // Stash the current env + caller pid before a db operation.
@@ -513,12 +367,7 @@ connection_stash_caller(connection_t* conn, ErlNifEnv* env)
 {
     conn->callback_env = env;
     enif_self(env, &conn->caller_pid);
-
-    // Reset cancel flag for new operation while holding cancel_tw
-    // to avoid racing with exqlite_cancel or other users of this flag.
-    tw_lock(&conn->cancel_tw);
     conn->cancelled = 0;
-    tw_unlock(&conn->cancel_tw);
 }
 
 // Clear the stashed caller after a db operation completes.
@@ -581,16 +430,13 @@ exqlite_open(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
     conn->interrupt_mutex = NULL;
     memset(conn->authorizer_deny, 0, sizeof(conn->authorizer_deny));
 
-    // Initialize cancellable busy handler fields early so destructor can safely
-    // call tw_destroy even if subsequent initialization steps fail.
-    tw_init(&conn->cancel_tw);
+    // Initialize busy handler fields
     conn->cancelled       = 0;
     conn->busy_timeout_ms = 2000; // default matches sqlite3_busy_timeout(db, 2000)
     conn->callback_env    = NULL;
 
     conn->interrupt_mutex = enif_mutex_create("exqlite:interrupt");
     if (conn->interrupt_mutex == NULL) {
-        // conn->db, conn->mutex, and conn->cancel_tw are set; destructor will clean them up.
         enif_release_resource(conn);
         return make_error_tuple(env, am_failed_to_create_mutex);
     }
@@ -1457,10 +1303,7 @@ connection_type_destructor(ErlNifEnv* env, void* arg)
 
     // Signal cancel to wake any busy handler that might still be sleeping,
     // so it returns and releases SQLite's db->mutex before we close.
-    tw_lock(&conn->cancel_tw);
     conn->cancelled = 1;
-    tw_signal(&conn->cancel_tw);
-    tw_unlock(&conn->cancel_tw);
 
     if (conn->db) {
         sqlite3_close_v2(conn->db);
@@ -1476,8 +1319,6 @@ connection_type_destructor(ErlNifEnv* env, void* arg)
         enif_mutex_destroy(conn->interrupt_mutex);
         conn->interrupt_mutex = NULL;
     }
-
-    tw_destroy(&conn->cancel_tw);
 }
 
 void
@@ -2019,10 +1860,7 @@ exqlite_set_busy_timeout(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
         return enif_make_badarg(env);
     }
 
-    // Protect write to busy_timeout_ms since busy handler reads it
-    tw_lock(&conn->cancel_tw);
     conn->busy_timeout_ms = timeout_ms;
-    tw_unlock(&conn->cancel_tw);
 
     return am_ok;
 }
@@ -2045,11 +1883,7 @@ exqlite_cancel(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
         return make_error_tuple(env, am_invalid_connection);
     }
 
-    // Set the cancel flag — busy handler and progress handler will see this
-    tw_lock(&conn->cancel_tw);
     conn->cancelled = 1;
-    tw_signal(&conn->cancel_tw);
-    tw_unlock(&conn->cancel_tw);
 
     // Also interrupt VDBE execution (same as interrupt/1)
     enif_mutex_lock(conn->interrupt_mutex);

--- a/c_src/sqlite3_nif.c
+++ b/c_src/sqlite3_nif.c
@@ -10,7 +10,6 @@
 #include <erl_nif.h>
 #include <sqlite3.h>
 
-
 static ERL_NIF_TERM am_ok;
 static ERL_NIF_TERM am_error;
 static ERL_NIF_TERM am_badarg;
@@ -330,7 +329,7 @@ exqlite_busy_handler(void* arg, int count)
         return 0;
 
     static const int delays[] = {1, 2, 5, 10, 15, 20, 25, 25, 25, 50, 50};
-    static const int ndelay = sizeof(delays) / sizeof(delays[0]);
+    static const int ndelay   = sizeof(delays) / sizeof(delays[0]);
 
     int total_waited = 0;
     for (int i = 0; i < count && i < ndelay; i++)
@@ -341,7 +340,7 @@ exqlite_busy_handler(void* arg, int count)
     if (total_waited >= conn->busy_timeout_ms)
         return 0;
 
-    int sleep_ms = (count < ndelay) ? delays[count] : 50;
+    int sleep_ms  = (count < ndelay) ? delays[count] : 50;
     int remaining = conn->busy_timeout_ms - total_waited;
     if (sleep_ms > remaining)
         sleep_ms = remaining;

--- a/c_src/sqlite3_nif.c
+++ b/c_src/sqlite3_nif.c
@@ -61,8 +61,9 @@ typedef struct connection
     int authorizer_deny[AUTHORIZER_DENY_SIZE];
 
     // Custom busy handler state
-    volatile int cancelled; // volatile for MSVC compat
+    volatile int cancelled; // guarded by interrupt_mutex
     int busy_timeout_ms;
+    int progress_handler_steps;
     ErlNifEnv* callback_env; // for enif_is_process_alive
     ErlNifPid caller_pid;
 } connection_t;
@@ -72,6 +73,8 @@ typedef struct statement
     connection_t* conn;
     sqlite3_stmt* statement;
 } statement_t;
+
+static int exqlite_progress_handler(void* arg);
 
 static void*
 exqlite_malloc(int bytes)
@@ -298,6 +301,24 @@ statement_release_lock(statement_t* statement)
     connection_release_lock(statement->conn);
 }
 
+static inline void
+connection_configure_progress_handler(connection_t* conn)
+{
+    assert(conn);
+    assert(conn->db);
+
+    if (conn->progress_handler_steps < 1) {
+        sqlite3_progress_handler(conn->db, 0, NULL, NULL);
+        return;
+    }
+
+    sqlite3_progress_handler(
+      conn->db,
+      conn->progress_handler_steps,
+      exqlite_progress_handler,
+      conn);
+}
+
 // ---------------------------------------------------------------------------
 // Custom busy handler
 //
@@ -311,40 +332,62 @@ static int
 exqlite_busy_handler(void* arg, int count)
 {
     connection_t* conn = (connection_t*)arg;
+    int cancelled;
+    int timeout_ms;
+    ErlNifEnv* callback_env;
+    ErlNifPid caller_pid;
 
-    if (conn->cancelled)
-        return 0;
+    enif_mutex_lock(conn->interrupt_mutex);
+    cancelled    = conn->cancelled;
+    timeout_ms   = conn->busy_timeout_ms;
+    callback_env = conn->callback_env;
+    caller_pid   = conn->caller_pid;
+    enif_mutex_unlock(conn->interrupt_mutex);
 
-    // Check if the calling process is still alive
-    if (conn->callback_env != NULL &&
-        !enif_is_process_alive(conn->callback_env, &conn->caller_pid)) {
-        conn->cancelled = 1;
+    if (cancelled) {
         return 0;
     }
 
-    if (conn->busy_timeout_ms <= 0)
+    // Check if the calling process is still alive
+    if (callback_env != NULL && !enif_is_process_alive(callback_env, &caller_pid)) {
+        enif_mutex_lock(conn->interrupt_mutex);
+        conn->cancelled = 1;
+        enif_mutex_unlock(conn->interrupt_mutex);
         return 0;
+    }
+
+    if (timeout_ms <= 0) {
+        return 0;
+    }
 
     static const int delays[] = {1, 2, 5, 10, 15, 20, 25, 25, 25, 50, 50};
     static const int ndelay   = sizeof(delays) / sizeof(delays[0]);
 
     int total_waited = 0;
-    for (int i = 0; i < count && i < ndelay; i++)
+    for (int i = 0; i < count && i < ndelay; i++) {
         total_waited += delays[i];
-    if (count >= ndelay)
+    }
+    if (count >= ndelay) {
         total_waited += (count - ndelay) * 50;
+    }
 
-    if (total_waited >= conn->busy_timeout_ms)
+    if (total_waited >= timeout_ms) {
         return 0;
+    }
 
     int sleep_ms  = (count < ndelay) ? delays[count] : 50;
-    int remaining = conn->busy_timeout_ms - total_waited;
-    if (sleep_ms > remaining)
+    int remaining = timeout_ms - total_waited;
+    if (sleep_ms > remaining) {
         sleep_ms = remaining;
+    }
 
     sqlite3_sleep(sleep_ms);
 
-    return conn->cancelled ? 0 : 1;
+    enif_mutex_lock(conn->interrupt_mutex);
+    cancelled = conn->cancelled;
+    enif_mutex_unlock(conn->interrupt_mutex);
+
+    return cancelled ? 0 : 1;
 }
 
 // Progress handler: fires every N VDBE opcodes.
@@ -353,7 +396,13 @@ static int
 exqlite_progress_handler(void* arg)
 {
     connection_t* conn = (connection_t*)arg;
-    return conn->cancelled ? 1 : 0;
+    int cancelled;
+
+    enif_mutex_lock(conn->interrupt_mutex);
+    cancelled = conn->cancelled;
+    enif_mutex_unlock(conn->interrupt_mutex);
+
+    return cancelled ? 1 : 0;
 }
 
 // Stash the current env + caller pid before a db operation.
@@ -361,16 +410,21 @@ exqlite_progress_handler(void* arg)
 static inline void
 connection_stash_caller(connection_t* conn, ErlNifEnv* env)
 {
+    enif_mutex_lock(conn->interrupt_mutex);
     conn->callback_env = env;
     enif_self(env, &conn->caller_pid);
     conn->cancelled = 0;
+    enif_mutex_unlock(conn->interrupt_mutex);
 }
 
 // Clear the stashed caller after a db operation completes.
+// Assumes that the `conn` has been locked for clearing the caller.
 static inline void
 connection_clear_caller(connection_t* conn)
 {
+    enif_mutex_lock(conn->interrupt_mutex);
     conn->callback_env = NULL;
+    enif_mutex_unlock(conn->interrupt_mutex);
 }
 
 ///
@@ -429,6 +483,7 @@ exqlite_open(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
     // Initialize busy handler fields
     conn->cancelled       = 0;
     conn->busy_timeout_ms = 2000; // default matches sqlite3_busy_timeout(db, 2000)
+    conn->progress_handler_steps = 1000;
     conn->callback_env    = NULL;
 
     conn->interrupt_mutex = enif_mutex_create("exqlite:interrupt");
@@ -439,7 +494,7 @@ exqlite_open(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 
     // Install our custom busy handler + progress handler
     sqlite3_busy_handler(db, exqlite_busy_handler, conn);
-    sqlite3_progress_handler(db, 1000, exqlite_progress_handler, conn);
+    connection_configure_progress_handler(conn);
 
     result = enif_make_resource(env, conn);
     enif_release_resource(conn);
@@ -1297,13 +1352,28 @@ connection_type_destructor(ErlNifEnv* env, void* arg)
 
     connection_t* conn = (connection_t*)arg;
 
-    // Signal cancel to wake any busy handler that might still be sleeping,
-    // so it returns and releases SQLite's db->mutex before we close.
-    conn->cancelled = 1;
+    if (conn->mutex) {
+        connection_acquire_lock(conn);
+    }
+
+    if (conn->interrupt_mutex) {
+        enif_mutex_lock(conn->interrupt_mutex);
+        // Signal cancel to wake any busy handler that might still be sleeping,
+        // so it returns and releases SQLite's db->mutex before we close.
+        conn->cancelled = 1;
+    }
 
     if (conn->db) {
         sqlite3_close_v2(conn->db);
         conn->db = NULL;
+    }
+
+    if (conn->interrupt_mutex) {
+        enif_mutex_unlock(conn->interrupt_mutex);
+    }
+
+    if (conn->mutex) {
+        connection_release_lock(conn);
     }
 
     if (conn->mutex) {
@@ -1856,7 +1926,55 @@ exqlite_set_busy_timeout(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
         return enif_make_badarg(env);
     }
 
+    connection_acquire_lock(conn);
+    if (conn->db == NULL) {
+        connection_release_lock(conn);
+        return make_error_tuple(env, am_connection_closed);
+    }
+
+    enif_mutex_lock(conn->interrupt_mutex);
     conn->busy_timeout_ms = timeout_ms;
+    enif_mutex_unlock(conn->interrupt_mutex);
+    connection_release_lock(conn);
+
+    return am_ok;
+}
+
+///
+/// Configure how often SQLite invokes the progress handler.
+/// Values less than 1 disable the progress handler entirely.
+///
+ERL_NIF_TERM
+exqlite_set_progress_handler_steps(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    assert(env);
+
+    connection_t* conn = NULL;
+    int steps;
+
+    if (argc != 2) {
+        return enif_make_badarg(env);
+    }
+
+    if (!enif_get_resource(env, argv[0], connection_type, (void**)&conn)) {
+        return make_error_tuple(env, am_invalid_connection);
+    }
+
+    if (!enif_get_int(env, argv[1], &steps)) {
+        return enif_make_badarg(env);
+    }
+
+    connection_acquire_lock(conn);
+    if (conn->db == NULL) {
+        connection_release_lock(conn);
+        return make_error_tuple(env, am_connection_closed);
+    }
+
+    enif_mutex_lock(conn->interrupt_mutex);
+    conn->progress_handler_steps = steps;
+    connection_configure_progress_handler(conn);
+    enif_mutex_unlock(conn->interrupt_mutex);
+    connection_release_lock(conn);
 
     return am_ok;
 }
@@ -1879,10 +1997,10 @@ exqlite_cancel(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
         return make_error_tuple(env, am_invalid_connection);
     }
 
-    conn->cancelled = 1;
-
-    // Also interrupt VDBE execution (same as interrupt/1)
+    // We deliberately avoid conn->mutex here: the running query holds it for
+    // the duration of the SQLite call, so taking it would block cancellation.
     enif_mutex_lock(conn->interrupt_mutex);
+    conn->cancelled = 1;
     if (conn->db != NULL) {
         sqlite3_interrupt(conn->db);
     }
@@ -1969,6 +2087,7 @@ static ErlNifFunc nif_funcs[] = {
   {"set_log_hook", 1, exqlite_set_log_hook, ERL_NIF_DIRTY_JOB_IO_BOUND},
   {"interrupt", 1, exqlite_interrupt, ERL_NIF_DIRTY_JOB_IO_BOUND},
   {"set_busy_timeout", 2, exqlite_set_busy_timeout, 0},
+  {"set_progress_handler_steps", 2, exqlite_set_progress_handler_steps, 0},
   {"cancel", 1, exqlite_cancel, 0},
   {"errmsg", 1, exqlite_errmsg},
   {"errstr", 1, exqlite_errstr},

--- a/c_src/sqlite3_nif.c
+++ b/c_src/sqlite3_nif.c
@@ -17,77 +17,109 @@
 // backends (pthreads and Win32), so #ifdef _WIN32 covers all platforms.
 
 #ifdef _WIN32
-#include <windows.h>
+    #include <windows.h>
 
-typedef struct {
+typedef struct
+{
     CRITICAL_SECTION cs;
     CONDITION_VARIABLE cv;
 } timed_wait_t;
 
-static void tw_init(timed_wait_t* tw)
+static void
+tw_init(timed_wait_t* tw)
 {
     InitializeCriticalSection(&tw->cs);
     InitializeConditionVariable(&tw->cv);
 }
 
-static void tw_destroy(timed_wait_t* tw)
+static void
+tw_destroy(timed_wait_t* tw)
 {
     DeleteCriticalSection(&tw->cs);
     // Windows CONDITION_VARIABLE has no destroy function
 }
 
-static void tw_lock(timed_wait_t* tw)   { EnterCriticalSection(&tw->cs); }
-static void tw_unlock(timed_wait_t* tw) { LeaveCriticalSection(&tw->cs); }
+static void
+tw_lock(timed_wait_t* tw)
+{
+    EnterCriticalSection(&tw->cs);
+}
+static void
+tw_unlock(timed_wait_t* tw)
+{
+    LeaveCriticalSection(&tw->cs);
+}
 
 // Returns 0 if signalled, 1 if timed out
-static int tw_wait_ms(timed_wait_t* tw, int ms)
+static int
+tw_wait_ms(timed_wait_t* tw, int ms)
 {
     return SleepConditionVariableCS(&tw->cv, &tw->cs, (DWORD)ms) ? 0 : 1;
 }
 
-static void tw_signal(timed_wait_t* tw) { WakeConditionVariable(&tw->cv); }
+static void
+tw_signal(timed_wait_t* tw)
+{
+    WakeConditionVariable(&tw->cv);
+}
 
 #else /* POSIX */
-#include <pthread.h>
-#include <time.h>
-#include <errno.h>
+    #include <pthread.h>
+    #include <time.h>
+    #include <errno.h>
 
-typedef struct {
+typedef struct
+{
     pthread_mutex_t mtx;
-    pthread_cond_t  cond;
+    pthread_cond_t cond;
 } timed_wait_t;
 
-static void tw_init(timed_wait_t* tw)
+static void
+tw_init(timed_wait_t* tw)
 {
     pthread_mutex_init(&tw->mtx, NULL);
     // CLOCK_REALTIME: macOS doesn't support CLOCK_MONOTONIC for condvars
     pthread_cond_init(&tw->cond, NULL);
 }
 
-static void tw_destroy(timed_wait_t* tw)
+static void
+tw_destroy(timed_wait_t* tw)
 {
     pthread_cond_destroy(&tw->cond);
     pthread_mutex_destroy(&tw->mtx);
 }
 
-static void tw_lock(timed_wait_t* tw)   { pthread_mutex_lock(&tw->mtx); }
-static void tw_unlock(timed_wait_t* tw) { pthread_mutex_unlock(&tw->mtx); }
+static void
+tw_lock(timed_wait_t* tw)
+{
+    pthread_mutex_lock(&tw->mtx);
+}
+static void
+tw_unlock(timed_wait_t* tw)
+{
+    pthread_mutex_unlock(&tw->mtx);
+}
 
 // Returns 0 if signalled, 1 if timed out
-static int tw_wait_ms(timed_wait_t* tw, int ms)
+static int
+tw_wait_ms(timed_wait_t* tw, int ms)
 {
     struct timespec ts;
     clock_gettime(CLOCK_REALTIME, &ts);
-    ts.tv_sec  += ms / 1000;
+    ts.tv_sec += ms / 1000;
     ts.tv_nsec += (ms % 1000) * 1000000L;
     if (ts.tv_nsec >= 1000000000L) {
-        ts.tv_sec  += 1;
+        ts.tv_sec += 1;
         ts.tv_nsec -= 1000000000L;
     }
     return pthread_cond_timedwait(&tw->cond, &tw->mtx, &ts) == ETIMEDOUT ? 1 : 0;
 }
 
-static void tw_signal(timed_wait_t* tw) { pthread_cond_signal(&tw->cond); }
+static void
+tw_signal(timed_wait_t* tw)
+{
+    pthread_cond_signal(&tw->cond);
+}
 
 #endif /* _WIN32 */
 
@@ -143,9 +175,9 @@ typedef struct connection
 
     // Custom busy handler state
     timed_wait_t cancel_tw;
-    volatile int cancelled;        // volatile for MSVC compat
+    volatile int cancelled; // volatile for MSVC compat
     int busy_timeout_ms;
-    ErlNifEnv* callback_env;       // for enif_is_process_alive
+    ErlNifEnv* callback_env; // for enif_is_process_alive
     ErlNifPid caller_pid;
 } connection_t;
 
@@ -399,20 +431,20 @@ exqlite_busy_handler(void* arg, int count)
 
     // Snapshot cancel state and timeout with lock held
     tw_lock(&conn->cancel_tw);
-    int cancelled = conn->cancelled;
+    int cancelled  = conn->cancelled;
     int timeout_ms = conn->busy_timeout_ms;
 
     // Check if the calling process is still alive
     if (!cancelled && conn->callback_env != NULL &&
         !enif_is_process_alive(conn->callback_env, &conn->caller_pid)) {
         conn->cancelled = 1;
-        cancelled = 1;
+        cancelled       = 1;
     }
     tw_unlock(&conn->cancel_tw);
 
     // Check if already cancelled
     if (cancelled) {
-        return 0;  // stop retrying → SQLite returns SQLITE_BUSY
+        return 0; // stop retrying → SQLite returns SQLITE_BUSY
     }
 
     // No timeout → fail immediately
@@ -424,7 +456,7 @@ exqlite_busy_handler(void* arg, int count)
     // Use the same delay schedule as SQLite's default busy handler
     // for the first few retries, then 50ms waits after that.
     static const int delays[] = {1, 2, 5, 10, 15, 20, 25, 25, 25, 50, 50};
-    static const int ndelay = sizeof(delays) / sizeof(delays[0]);
+    static const int ndelay   = sizeof(delays) / sizeof(delays[0]);
 
     int total_waited = 0;
     for (int i = 0; i < count && i < ndelay; i++) {
@@ -435,11 +467,11 @@ exqlite_busy_handler(void* arg, int count)
     }
 
     if (total_waited >= timeout_ms) {
-        return 0;  // timeout exceeded
+        return 0; // timeout exceeded
     }
 
     // Calculate sleep duration for this iteration
-    int sleep_ms = (count < ndelay) ? delays[count] : 50;
+    int sleep_ms  = (count < ndelay) ? delays[count] : 50;
     int remaining = timeout_ms - total_waited;
     if (sleep_ms > remaining) {
         sleep_ms = remaining;
@@ -447,29 +479,31 @@ exqlite_busy_handler(void* arg, int count)
 
     // Wait on the condvar — can be woken early by cancel()
     tw_lock(&conn->cancel_tw);
-    if (!conn->cancelled) {
+    int cancelled = conn->cancelled;
+    if (!cancelled) {
         tw_wait_ms(&conn->cancel_tw, sleep_ms);
+        cancelled = conn->cancelled; // snapshot again after waking
     }
     tw_unlock(&conn->cancel_tw);
 
-    // After waking, check cancel again
-    if (conn->cancelled) {
+    // After waking, use the snapshot to avoid data race
+    if (cancelled) {
         return 0;
     }
 
-    return 1;  // retry the operation
+    return 1; // retry the operation
 }
 
 // Progress handler: fires every N VDBE opcodes.
 // Returns non-zero to interrupt execution when cancelled.
-// Note: reads cancelled without lock for performance (fires every 1000 opcodes).
-// Worst case is one extra iteration before seeing the flag. sqlite3_interrupt()
-// provides a redundant cancellation path.
 static int
 exqlite_progress_handler(void* arg)
 {
     connection_t* conn = (connection_t*)arg;
-    return conn->cancelled ? 1 : 0;
+    tw_lock(&conn->cancel_tw);
+    int cancelled = conn->cancelled;
+    tw_unlock(&conn->cancel_tw);
+    return cancelled ? 1 : 0;
 }
 
 // Stash the current env + caller pid before a db operation.
@@ -479,7 +513,7 @@ connection_stash_caller(connection_t* conn, ErlNifEnv* env)
 {
     conn->callback_env = env;
     enif_self(env, &conn->caller_pid);
-    
+
     // Reset cancel flag for new operation while holding cancel_tw
     // to avoid racing with exqlite_cancel or other users of this flag.
     tw_lock(&conn->cancel_tw);
@@ -551,7 +585,7 @@ exqlite_open(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
     // call tw_destroy even if subsequent initialization steps fail.
     tw_init(&conn->cancel_tw);
     conn->cancelled       = 0;
-    conn->busy_timeout_ms = 2000;  // default matches sqlite3_busy_timeout(db, 2000)
+    conn->busy_timeout_ms = 2000; // default matches sqlite3_busy_timeout(db, 2000)
     conn->callback_env    = NULL;
 
     conn->interrupt_mutex = enif_mutex_create("exqlite:interrupt");

--- a/c_src/sqlite3_nif.c
+++ b/c_src/sqlite3_nif.c
@@ -302,12 +302,9 @@ statement_release_lock(statement_t* statement)
 // Custom busy handler
 //
 // Replaces SQLite's default busy handler (which sleeps via sqlite3OsSleep and
-// cannot be interrupted) with one that waits on a condvar.  This lets cancel()
-// signal the condvar and wake the handler immediately, so disconnect() can
-// proceed without waiting for the full busy_timeout.
-//
-// Lock ordering: db->mutex (held by SQLite during busy callback) → cancel_tw.
-// The cancel path only acquires cancel_tw, never db->mutex, so no deadlock.
+// cannot be interrupted) with one that polls conn->cancelled between each
+// sqlite3_sleep() call.  cancel() sets the flag and calls sqlite3_interrupt()
+// so disconnect() wakes within at most one sleep interval (~10ms).
 // ---------------------------------------------------------------------------
 
 static int
@@ -1865,7 +1862,7 @@ exqlite_set_busy_timeout(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 }
 
 /// Cancel: wake busy handler + interrupt VDBE.
-/// Superset of interrupt/1: sets flag, signals condvar, calls sqlite3_interrupt().
+/// Superset of interrupt/1: sets cancelled flag + calls sqlite3_interrupt().
 ///
 ERL_NIF_TERM
 exqlite_cancel(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])

--- a/c_src/sqlite3_nif.c
+++ b/c_src/sqlite3_nif.c
@@ -418,7 +418,8 @@ connection_stash_caller(connection_t* conn, ErlNifEnv* env)
 }
 
 // Clear the stashed caller after a db operation completes.
-// Assumes that the `conn` has been locked for clearing the caller.
+// Assumes that the `conn` has been locked for clearing the
+// caller.
 static inline void
 connection_clear_caller(connection_t* conn)
 {

--- a/c_src/sqlite3_nif.c
+++ b/c_src/sqlite3_nif.c
@@ -10,14 +10,11 @@
 #include <erl_nif.h>
 #include <sqlite3.h>
 
-// ---------------------------------------------------------------------------
 // Platform timed-wait abstraction
 //
-// We need pthread_cond_timedwait / SleepConditionVariableCS because OTP's
-// enif_cond does not expose a timed wait (deliberate omission due to clock
-// jump safety concerns in telecom).  BEAM has exactly two threading backends
-// (pthreads and Win32), so #ifdef _WIN32 covers 100% of supported platforms.
-// ---------------------------------------------------------------------------
+// OTP doesn't provide enif_cond_timedwait, so we wrap pthread_cond_timedwait
+// (POSIX) and SleepConditionVariableCS (Windows). BEAM has two threading
+// backends (pthreads and Win32), so #ifdef _WIN32 covers all platforms.
 
 #ifdef _WIN32
 #include <windows.h>
@@ -63,8 +60,7 @@ typedef struct {
 static void tw_init(timed_wait_t* tw)
 {
     pthread_mutex_init(&tw->mtx, NULL);
-    // Use CLOCK_REALTIME (the default) because macOS doesn't support
-    // pthread_condattr_setclock(CLOCK_MONOTONIC).
+    // CLOCK_REALTIME: macOS doesn't support CLOCK_MONOTONIC for condvars
     pthread_cond_init(&tw->cond, NULL);
 }
 
@@ -146,11 +142,11 @@ typedef struct connection
     int authorizer_deny[AUTHORIZER_DENY_SIZE];
 
     // Custom busy handler state
-    timed_wait_t cancel_tw;        // condvar for cancellable busy waits
-    volatile int cancelled;        // 1 = cancel requested (volatile for MSVC compat)
-    int busy_timeout_ms;           // total busy timeout in milliseconds
-    ErlNifEnv* callback_env;       // env for enif_is_process_alive checks
-    ErlNifPid caller_pid;          // pid of the process that started the current op
+    timed_wait_t cancel_tw;
+    volatile int cancelled;        // volatile for MSVC compat
+    int busy_timeout_ms;
+    ErlNifEnv* callback_env;       // for enif_is_process_alive
+    ErlNifPid caller_pid;
 } connection_t;
 
 typedef struct statement
@@ -1966,11 +1962,8 @@ exqlite_interrupt(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 }
 
 ///
-/// Set the busy timeout without destroying the custom busy handler.
-///
-/// Unlike PRAGMA busy_timeout (which internally calls sqlite3_busy_timeout()
-/// and replaces any custom handler), this NIF only updates the timeout value
-/// that our custom handler reads.
+/// Set busy timeout without destroying the custom handler.
+/// (PRAGMA busy_timeout calls sqlite3_busy_timeout() which replaces handlers)
 ///
 ERL_NIF_TERM
 exqlite_set_busy_timeout(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
@@ -2000,11 +1993,8 @@ exqlite_set_busy_timeout(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
     return am_ok;
 }
 
-///
-/// Cancel a running query: wake the busy handler and interrupt VDBE execution.
-///
-/// This is a superset of interrupt/1 — it sets the cancel flag, signals the
-/// condvar to wake any busy handler sleep, AND calls sqlite3_interrupt().
+/// Cancel: wake busy handler + interrupt VDBE.
+/// Superset of interrupt/1: sets flag, signals condvar, calls sqlite3_interrupt().
 ///
 ERL_NIF_TERM
 exqlite_cancel(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])

--- a/c_src/sqlite3_nif.c
+++ b/c_src/sqlite3_nif.c
@@ -481,10 +481,10 @@ exqlite_open(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
     memset(conn->authorizer_deny, 0, sizeof(conn->authorizer_deny));
 
     // Initialize busy handler fields
-    conn->cancelled       = 0;
-    conn->busy_timeout_ms = 2000; // default matches sqlite3_busy_timeout(db, 2000)
+    conn->cancelled              = 0;
+    conn->busy_timeout_ms        = 2000; // default matches sqlite3_busy_timeout(db, 2000)
     conn->progress_handler_steps = 1000;
-    conn->callback_env    = NULL;
+    conn->callback_env           = NULL;
 
     conn->interrupt_mutex = enif_mutex_create("exqlite:interrupt");
     if (conn->interrupt_mutex == NULL) {

--- a/c_src/sqlite3_nif.c
+++ b/c_src/sqlite3_nif.c
@@ -548,19 +548,22 @@ exqlite_open(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
     }
     conn->db              = db;
     conn->mutex           = mutex;
-    conn->interrupt_mutex = enif_mutex_create("exqlite:interrupt");
+    conn->interrupt_mutex = NULL;
     memset(conn->authorizer_deny, 0, sizeof(conn->authorizer_deny));
-    if (conn->interrupt_mutex == NULL) {
-        // conn->db and conn->mutex are set; the destructor will clean them up.
-        enif_release_resource(conn);
-        return make_error_tuple(env, am_failed_to_create_mutex);
-    }
 
-    // Initialize cancellable busy handler
+    // Initialize cancellable busy handler fields early so destructor can safely
+    // call tw_destroy even if subsequent initialization steps fail.
     tw_init(&conn->cancel_tw);
     conn->cancelled       = 0;
     conn->busy_timeout_ms = 2000;  // default matches sqlite3_busy_timeout(db, 2000)
     conn->callback_env    = NULL;
+
+    conn->interrupt_mutex = enif_mutex_create("exqlite:interrupt");
+    if (conn->interrupt_mutex == NULL) {
+        // conn->db, conn->mutex, and conn->cancel_tw are set; destructor will clean them up.
+        enif_release_resource(conn);
+        return make_error_tuple(env, am_failed_to_create_mutex);
+    }
 
     // Install our custom busy handler + progress handler
     sqlite3_busy_handler(db, exqlite_busy_handler, conn);

--- a/c_src/sqlite3_nif.c
+++ b/c_src/sqlite3_nif.c
@@ -1989,7 +1989,10 @@ exqlite_set_busy_timeout(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
         return enif_make_badarg(env);
     }
 
+    // Protect write to busy_timeout_ms since busy handler reads it
+    tw_lock(&conn->cancel_tw);
     conn->busy_timeout_ms = timeout_ms;
+    tw_unlock(&conn->cancel_tw);
 
     return am_ok;
 }

--- a/c_src/sqlite3_nif.c
+++ b/c_src/sqlite3_nif.c
@@ -10,6 +10,91 @@
 #include <erl_nif.h>
 #include <sqlite3.h>
 
+// ---------------------------------------------------------------------------
+// Platform timed-wait abstraction
+//
+// We need pthread_cond_timedwait / SleepConditionVariableCS because OTP's
+// enif_cond does not expose a timed wait (deliberate omission due to clock
+// jump safety concerns in telecom).  BEAM has exactly two threading backends
+// (pthreads and Win32), so #ifdef _WIN32 covers 100% of supported platforms.
+// ---------------------------------------------------------------------------
+
+#ifdef _WIN32
+#include <windows.h>
+
+typedef struct {
+    CRITICAL_SECTION cs;
+    CONDITION_VARIABLE cv;
+} timed_wait_t;
+
+static void tw_init(timed_wait_t* tw)
+{
+    InitializeCriticalSection(&tw->cs);
+    InitializeConditionVariable(&tw->cv);
+}
+
+static void tw_destroy(timed_wait_t* tw)
+{
+    DeleteCriticalSection(&tw->cs);
+    // Windows CONDITION_VARIABLE has no destroy function
+}
+
+static void tw_lock(timed_wait_t* tw)   { EnterCriticalSection(&tw->cs); }
+static void tw_unlock(timed_wait_t* tw) { LeaveCriticalSection(&tw->cs); }
+
+// Returns 0 if signalled, 1 if timed out
+static int tw_wait_ms(timed_wait_t* tw, int ms)
+{
+    return SleepConditionVariableCS(&tw->cv, &tw->cs, (DWORD)ms) ? 0 : 1;
+}
+
+static void tw_signal(timed_wait_t* tw) { WakeConditionVariable(&tw->cv); }
+
+#else /* POSIX */
+#include <pthread.h>
+#include <time.h>
+#include <errno.h>
+
+typedef struct {
+    pthread_mutex_t mtx;
+    pthread_cond_t  cond;
+} timed_wait_t;
+
+static void tw_init(timed_wait_t* tw)
+{
+    pthread_mutex_init(&tw->mtx, NULL);
+    // Use CLOCK_REALTIME (the default) because macOS doesn't support
+    // pthread_condattr_setclock(CLOCK_MONOTONIC).
+    pthread_cond_init(&tw->cond, NULL);
+}
+
+static void tw_destroy(timed_wait_t* tw)
+{
+    pthread_cond_destroy(&tw->cond);
+    pthread_mutex_destroy(&tw->mtx);
+}
+
+static void tw_lock(timed_wait_t* tw)   { pthread_mutex_lock(&tw->mtx); }
+static void tw_unlock(timed_wait_t* tw) { pthread_mutex_unlock(&tw->mtx); }
+
+// Returns 0 if signalled, 1 if timed out
+static int tw_wait_ms(timed_wait_t* tw, int ms)
+{
+    struct timespec ts;
+    clock_gettime(CLOCK_REALTIME, &ts);
+    ts.tv_sec  += ms / 1000;
+    ts.tv_nsec += (ms % 1000) * 1000000L;
+    if (ts.tv_nsec >= 1000000000L) {
+        ts.tv_sec  += 1;
+        ts.tv_nsec -= 1000000000L;
+    }
+    return pthread_cond_timedwait(&tw->cond, &tw->mtx, &ts) == ETIMEDOUT ? 1 : 0;
+}
+
+static void tw_signal(timed_wait_t* tw) { pthread_cond_signal(&tw->cond); }
+
+#endif /* _WIN32 */
+
 static ERL_NIF_TERM am_ok;
 static ERL_NIF_TERM am_error;
 static ERL_NIF_TERM am_badarg;
@@ -59,6 +144,13 @@ typedef struct connection
     ErlNifMutex* interrupt_mutex;
     ErlNifPid update_hook_pid;
     int authorizer_deny[AUTHORIZER_DENY_SIZE];
+
+    // Custom busy handler state
+    timed_wait_t cancel_tw;        // condvar for cancellable busy waits
+    volatile int cancelled;        // 1 = cancel requested (volatile for MSVC compat)
+    int busy_timeout_ms;           // total busy timeout in milliseconds
+    ErlNifEnv* callback_env;       // env for enif_is_process_alive checks
+    ErlNifPid caller_pid;          // pid of the process that started the current op
 } connection_t;
 
 typedef struct statement
@@ -292,6 +384,120 @@ statement_release_lock(statement_t* statement)
     connection_release_lock(statement->conn);
 }
 
+// ---------------------------------------------------------------------------
+// Custom busy handler
+//
+// Replaces SQLite's default busy handler (which sleeps via sqlite3OsSleep and
+// cannot be interrupted) with one that waits on a condvar.  This lets cancel()
+// signal the condvar and wake the handler immediately, so disconnect() can
+// proceed without waiting for the full busy_timeout.
+//
+// Lock ordering: db->mutex (held by SQLite during busy callback) → cancel_tw.
+// The cancel path only acquires cancel_tw, never db->mutex, so no deadlock.
+// ---------------------------------------------------------------------------
+
+static int
+exqlite_busy_handler(void* arg, int count)
+{
+    connection_t* conn = (connection_t*)arg;
+
+    // Snapshot cancel state and timeout with lock held
+    tw_lock(&conn->cancel_tw);
+    int cancelled = conn->cancelled;
+    int timeout_ms = conn->busy_timeout_ms;
+
+    // Check if the calling process is still alive
+    if (!cancelled && conn->callback_env != NULL &&
+        !enif_is_process_alive(conn->callback_env, &conn->caller_pid)) {
+        conn->cancelled = 1;
+        cancelled = 1;
+    }
+    tw_unlock(&conn->cancel_tw);
+
+    // Check if already cancelled
+    if (cancelled) {
+        return 0;  // stop retrying → SQLite returns SQLITE_BUSY
+    }
+
+    // No timeout → fail immediately
+    if (timeout_ms <= 0) {
+        return 0;
+    }
+
+    // Calculate how much time we've already waited.
+    // Use the same delay schedule as SQLite's default busy handler
+    // for the first few retries, then 50ms waits after that.
+    static const int delays[] = {1, 2, 5, 10, 15, 20, 25, 25, 25, 50, 50};
+    static const int ndelay = sizeof(delays) / sizeof(delays[0]);
+
+    int total_waited = 0;
+    for (int i = 0; i < count && i < ndelay; i++) {
+        total_waited += delays[i];
+    }
+    if (count >= ndelay) {
+        total_waited += (count - ndelay) * 50;
+    }
+
+    if (total_waited >= timeout_ms) {
+        return 0;  // timeout exceeded
+    }
+
+    // Calculate sleep duration for this iteration
+    int sleep_ms = (count < ndelay) ? delays[count] : 50;
+    int remaining = timeout_ms - total_waited;
+    if (sleep_ms > remaining) {
+        sleep_ms = remaining;
+    }
+
+    // Wait on the condvar — can be woken early by cancel()
+    tw_lock(&conn->cancel_tw);
+    if (!conn->cancelled) {
+        tw_wait_ms(&conn->cancel_tw, sleep_ms);
+    }
+    tw_unlock(&conn->cancel_tw);
+
+    // After waking, check cancel again
+    if (conn->cancelled) {
+        return 0;
+    }
+
+    return 1;  // retry the operation
+}
+
+// Progress handler: fires every N VDBE opcodes.
+// Returns non-zero to interrupt execution when cancelled.
+// Note: reads cancelled without lock for performance (fires every 1000 opcodes).
+// Worst case is one extra iteration before seeing the flag. sqlite3_interrupt()
+// provides a redundant cancellation path.
+static int
+exqlite_progress_handler(void* arg)
+{
+    connection_t* conn = (connection_t*)arg;
+    return conn->cancelled ? 1 : 0;
+}
+
+// Stash the current env + caller pid before a db operation.
+// Must be called while holding conn->mutex.
+static inline void
+connection_stash_caller(connection_t* conn, ErlNifEnv* env)
+{
+    conn->callback_env = env;
+    enif_self(env, &conn->caller_pid);
+    
+    // Reset cancel flag for new operation while holding cancel_tw
+    // to avoid racing with exqlite_cancel or other users of this flag.
+    tw_lock(&conn->cancel_tw);
+    conn->cancelled = 0;
+    tw_unlock(&conn->cancel_tw);
+}
+
+// Clear the stashed caller after a db operation completes.
+static inline void
+connection_clear_caller(connection_t* conn)
+{
+    conn->callback_env = NULL;
+}
+
 ///
 /// Opens a new SQLite database
 ///
@@ -334,8 +540,6 @@ exqlite_open(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
         return make_error_tuple(env, am_failed_to_create_mutex);
     }
 
-    sqlite3_busy_timeout(db, 2000);
-
     conn = enif_alloc_resource(connection_type, sizeof(connection_t));
     if (!conn) {
         sqlite3_close_v2(db);
@@ -351,6 +555,16 @@ exqlite_open(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
         enif_release_resource(conn);
         return make_error_tuple(env, am_failed_to_create_mutex);
     }
+
+    // Initialize cancellable busy handler
+    tw_init(&conn->cancel_tw);
+    conn->cancelled       = 0;
+    conn->busy_timeout_ms = 2000;  // default matches sqlite3_busy_timeout(db, 2000)
+    conn->callback_env    = NULL;
+
+    // Install our custom busy handler + progress handler
+    sqlite3_busy_handler(db, exqlite_busy_handler, conn);
+    sqlite3_progress_handler(db, 1000, exqlite_progress_handler, conn);
 
     result = enif_make_resource(env, conn);
     enif_release_resource(conn);
@@ -381,9 +595,11 @@ exqlite_close(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
     // cases. Cases such as query timeout and connection pooling
     // attempting to close the connection
     connection_acquire_lock(conn);
+    connection_stash_caller(conn, env);
 
     // DB is already closed, nothing to do here.
     if (conn->db == NULL) {
+        connection_clear_caller(conn);
         connection_release_lock(conn);
         return am_ok;
     }
@@ -392,6 +608,7 @@ exqlite_close(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
     if (autocommit == 0) {
         rc = sqlite3_exec(conn->db, "ROLLBACK;", NULL, NULL, NULL);
         if (rc != SQLITE_OK) {
+            connection_clear_caller(conn);
             connection_release_lock(conn);
             return make_sqlite3_error_tuple(env, rc, conn->db);
         }
@@ -417,6 +634,7 @@ exqlite_close(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
     conn->db = NULL;
     enif_mutex_unlock(conn->interrupt_mutex);
 
+    connection_clear_caller(conn);
     connection_release_lock(conn);
 
     return am_ok;
@@ -448,18 +666,22 @@ exqlite_execute(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
     }
 
     connection_acquire_lock(conn);
+    connection_stash_caller(conn, env);
 
     if (conn->db == NULL) {
+        connection_clear_caller(conn);
         connection_release_lock(conn);
         return make_error_tuple(env, am_connection_closed);
     }
 
     rc = sqlite3_exec(conn->db, (char*)bin.data, NULL, NULL, NULL);
     if (rc != SQLITE_OK) {
+        connection_clear_caller(conn);
         connection_release_lock(conn);
         return make_sqlite3_error_tuple(env, rc, conn->db);
     }
 
+    connection_clear_caller(conn);
     connection_release_lock(conn);
 
     return am_ok;
@@ -531,7 +753,9 @@ exqlite_prepare(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 
     // ensure connection is not getting closed by parallel thread
     connection_acquire_lock(conn);
+    connection_stash_caller(conn, env);
     if (conn->db == NULL) {
+        connection_clear_caller(conn);
         connection_release_lock(conn);
         enif_release_resource(statement);
         return make_error_tuple(env, am_connection_closed);
@@ -541,11 +765,13 @@ exqlite_prepare(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 
     if (rc != SQLITE_OK) {
         result = make_sqlite3_error_tuple(env, rc, conn->db);
+        connection_clear_caller(conn);
         connection_release_lock(conn);
         enif_release_resource(statement);
         return result;
     }
 
+    connection_clear_caller(conn);
     connection_release_lock(conn);
 
     result = enif_make_resource(env, statement);
@@ -814,8 +1040,10 @@ exqlite_multi_step(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
     }
 
     connection_acquire_lock(conn);
+    connection_stash_caller(conn, env);
 
     if (statement->statement == NULL) {
+        connection_clear_caller(conn);
         connection_release_lock(conn);
         return make_error_tuple(env, am_invalid_statement);
     }
@@ -828,11 +1056,13 @@ exqlite_multi_step(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
         switch (rc) {
             case SQLITE_BUSY:
                 sqlite3_reset(statement->statement);
+                connection_clear_caller(conn);
                 connection_release_lock(conn);
                 return am_busy;
 
             case SQLITE_DONE:
                 sqlite3_reset(statement->statement);
+                connection_clear_caller(conn);
                 connection_release_lock(conn);
                 return enif_make_tuple2(env, am_done, rows);
 
@@ -843,11 +1073,13 @@ exqlite_multi_step(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 
             default:
                 sqlite3_reset(statement->statement);
+                connection_clear_caller(conn);
                 connection_release_lock(conn);
                 return make_sqlite3_error_tuple(env, rc, conn->db);
         }
     }
 
+    connection_clear_caller(conn);
     connection_release_lock(conn);
 
     return enif_make_tuple2(env, am_rows, rows);
@@ -880,8 +1112,10 @@ exqlite_step(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
     }
 
     connection_acquire_lock(conn);
+    connection_stash_caller(conn, env);
 
     if (statement->statement == NULL) {
+        connection_clear_caller(conn);
         connection_release_lock(conn);
         return make_error_tuple(env, am_invalid_statement);
     }
@@ -890,19 +1124,23 @@ exqlite_step(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
     switch (rc) {
         case SQLITE_ROW:
             result = enif_make_tuple2(env, am_row, make_row(env, statement->statement));
+            connection_clear_caller(conn);
             connection_release_lock(conn);
             return result;
         case SQLITE_BUSY:
             sqlite3_reset(statement->statement);
+            connection_clear_caller(conn);
             connection_release_lock(conn);
             return am_busy;
         case SQLITE_DONE:
             sqlite3_reset(statement->statement);
+            connection_clear_caller(conn);
             connection_release_lock(conn);
             return am_done;
         default:
             sqlite3_reset(statement->statement);
             result = make_sqlite3_error_tuple(env, rc, conn->db);
+            connection_clear_caller(conn);
             connection_release_lock(conn);
             return result;
     }
@@ -1184,6 +1422,13 @@ connection_type_destructor(ErlNifEnv* env, void* arg)
 
     connection_t* conn = (connection_t*)arg;
 
+    // Signal cancel to wake any busy handler that might still be sleeping,
+    // so it returns and releases SQLite's db->mutex before we close.
+    tw_lock(&conn->cancel_tw);
+    conn->cancelled = 1;
+    tw_signal(&conn->cancel_tw);
+    tw_unlock(&conn->cancel_tw);
+
     if (conn->db) {
         sqlite3_close_v2(conn->db);
         conn->db = NULL;
@@ -1198,6 +1443,8 @@ connection_type_destructor(ErlNifEnv* env, void* arg)
         enif_mutex_destroy(conn->interrupt_mutex);
         conn->interrupt_mutex = NULL;
     }
+
+    tw_destroy(&conn->cancel_tw);
 }
 
 void
@@ -1715,6 +1962,75 @@ exqlite_interrupt(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
     return am_ok;
 }
 
+///
+/// Set the busy timeout without destroying the custom busy handler.
+///
+/// Unlike PRAGMA busy_timeout (which internally calls sqlite3_busy_timeout()
+/// and replaces any custom handler), this NIF only updates the timeout value
+/// that our custom handler reads.
+///
+ERL_NIF_TERM
+exqlite_set_busy_timeout(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    assert(env);
+
+    connection_t* conn = NULL;
+    int timeout_ms;
+
+    if (argc != 2) {
+        return enif_make_badarg(env);
+    }
+
+    if (!enif_get_resource(env, argv[0], connection_type, (void**)&conn)) {
+        return make_error_tuple(env, am_invalid_connection);
+    }
+
+    if (!enif_get_int(env, argv[1], &timeout_ms)) {
+        return enif_make_badarg(env);
+    }
+
+    conn->busy_timeout_ms = timeout_ms;
+
+    return am_ok;
+}
+
+///
+/// Cancel a running query: wake the busy handler and interrupt VDBE execution.
+///
+/// This is a superset of interrupt/1 — it sets the cancel flag, signals the
+/// condvar to wake any busy handler sleep, AND calls sqlite3_interrupt().
+///
+ERL_NIF_TERM
+exqlite_cancel(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    assert(env);
+
+    connection_t* conn = NULL;
+
+    if (argc != 1) {
+        return enif_make_badarg(env);
+    }
+
+    if (!enif_get_resource(env, argv[0], connection_type, (void**)&conn)) {
+        return make_error_tuple(env, am_invalid_connection);
+    }
+
+    // Set the cancel flag — busy handler and progress handler will see this
+    tw_lock(&conn->cancel_tw);
+    conn->cancelled = 1;
+    tw_signal(&conn->cancel_tw);
+    tw_unlock(&conn->cancel_tw);
+
+    // Also interrupt VDBE execution (same as interrupt/1)
+    enif_mutex_lock(conn->interrupt_mutex);
+    if (conn->db != NULL) {
+        sqlite3_interrupt(conn->db);
+    }
+    enif_mutex_unlock(conn->interrupt_mutex);
+
+    return am_ok;
+}
+
 ERL_NIF_TERM
 exqlite_errmsg(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 {
@@ -1792,6 +2108,8 @@ static ErlNifFunc nif_funcs[] = {
   {"set_authorizer", 2, exqlite_set_authorizer, ERL_NIF_DIRTY_JOB_IO_BOUND},
   {"set_log_hook", 1, exqlite_set_log_hook, ERL_NIF_DIRTY_JOB_IO_BOUND},
   {"interrupt", 1, exqlite_interrupt, ERL_NIF_DIRTY_JOB_IO_BOUND},
+  {"set_busy_timeout", 2, exqlite_set_busy_timeout, 0},
+  {"cancel", 1, exqlite_cancel, 0},
   {"errmsg", 1, exqlite_errmsg},
   {"errstr", 1, exqlite_errstr},
 };

--- a/lib/exqlite/connection.ex
+++ b/lib/exqlite/connection.ex
@@ -212,8 +212,8 @@ defmodule Exqlite.Connection do
       apply(state.before_disconnect, [err, state])
     end
 
-    # Cancel any in-flight query: wake the busy handler condvar AND interrupt
-    # VDBE execution so close() doesn't block on conn->mutex.
+    # Cancel any in-flight query: set the cancelled flag AND interrupt VDBE
+    # execution so close() doesn't block on conn->mutex.
     # This is a superset of the old Sqlite3.interrupt(db) call.
     # See: https://github.com/elixir-sqlite/exqlite/issues/192
     Sqlite3.cancel(db)

--- a/lib/exqlite/connection.ex
+++ b/lib/exqlite/connection.ex
@@ -74,6 +74,7 @@ defmodule Exqlite.Connection do
           | {:secure_delete, :on | :off}
           | {:wal_auto_check_point, integer()}
           | {:busy_timeout, integer()}
+          | {:progress_handler_steps, integer()}
           | {:chunk_size, integer()}
           | {:journal_size_limit, integer()}
           | {:soft_heap_limit, integer()}
@@ -135,6 +136,10 @@ defmodule Exqlite.Connection do
       negative value turns auto-checkpointing off.
     * `:busy_timeout` - Sets the busy timeout in milliseconds for a connection.
       Default is `2000`.
+    * `:progress_handler_steps` - Controls how often SQLite runs the progress
+      handler used for query cancellation. Default is `1000`. Values less than
+      `1` disable the progress handler, which reduces per-op overhead but means
+      `interrupt/1` only takes effect once SQLite returns from the current call.
     * `:chunk_size` - The chunk size for bulk fetching. Defaults to `50`.
     * `:key` - Optional key to set during database initialization. This PRAGMA
       is often used to set up database level encryption.
@@ -519,6 +524,13 @@ defmodule Exqlite.Connection do
     Sqlite3.set_busy_timeout(db, Pragma.busy_timeout(options))
   end
 
+  defp set_progress_handler_steps(db, options) do
+    Sqlite3.set_progress_handler_steps(
+      db,
+      Keyword.get(options, :progress_handler_steps, 1000)
+    )
+  end
+
   defp deserialize(db, options) do
     case Keyword.get(options, :serialized, nil) do
       nil -> :ok
@@ -568,6 +580,7 @@ defmodule Exqlite.Connection do
          :ok <- set_wal_auto_check_point(db, options),
          :ok <- set_case_sensitive_like(db, options),
          :ok <- set_busy_timeout(db, options),
+         :ok <- set_progress_handler_steps(db, options),
          :ok <- set_journal_size_limit(db, options),
          :ok <- set_soft_heap_limit(db, options),
          :ok <- set_hard_heap_limit(db, options),

--- a/lib/exqlite/connection.ex
+++ b/lib/exqlite/connection.ex
@@ -135,11 +135,14 @@ defmodule Exqlite.Connection do
       interval. Default is `1000`. Setting the auto-checkpoint size to zero or a
       negative value turns auto-checkpointing off.
     * `:busy_timeout` - Sets the busy timeout in milliseconds for a connection.
-      Default is `2000`.
+      Default is `2000`. This is applied via `Exqlite.Sqlite3.set_busy_timeout/2`
+      so Exqlite keeps its custom busy handler installed. Set it to `0` if you
+      want lock contention to fail immediately instead of sleeping and retrying.
     * `:progress_handler_steps` - Controls how often SQLite runs the progress
       handler used for query cancellation. Default is `1000`. Values less than
       `1` disable the progress handler, which reduces per-op overhead but means
-      `interrupt/1` only takes effect once SQLite returns from the current call.
+      `interrupt/1` and `cancel/1` only take effect once SQLite returns from the
+      current call.
     * `:chunk_size` - The chunk size for bulk fetching. Defaults to `50`.
     * `:key` - Optional key to set during database initialization. This PRAGMA
       is often used to set up database level encryption.
@@ -179,6 +182,18 @@ defmodule Exqlite.Connection do
       `t:Exqlite.Connection.t/0` prepended to `args` or `nil` (default: `nil`)
 
   For more information about the options above, see [sqlite documentation][1]
+
+  ## Cancellation notes
+
+  Exqlite exposes two low-level cancellation APIs:
+
+    * `Exqlite.Sqlite3.interrupt/1` interrupts SQLite while it is executing a
+      statement.
+    * `Exqlite.Sqlite3.cancel/1` is stronger: it also wakes the custom busy
+      handler if the connection is sleeping while waiting on a lock.
+
+  Connection teardown uses `cancel/1` so DBConnection timeouts and disconnects
+  can break out of both long-running statements and busy waits.
 
   [1]: https://www.sqlite.org/pragma.html
   """

--- a/lib/exqlite/sqlite3.ex
+++ b/lib/exqlite/sqlite3.ex
@@ -87,6 +87,11 @@ defmodule Exqlite.Sqlite3 do
   @doc """
   Interrupt a long-running query.
 
+  This calls `sqlite3_interrupt()` and is effective while SQLite is actively
+  executing a statement. It does not wake the custom busy handler while the
+  connection is sleeping and waiting on a lock. Use `cancel/1` when you need
+  to abort both statement execution and busy waits.
+
   > #### Warning {: .warning}
   > If you are going to interrupt a long running process, it is unsafe to call
   > `close/1` immediately after. You run the risk of undefined behavior. This
@@ -107,6 +112,12 @@ defmodule Exqlite.Sqlite3 do
   and replaces any custom handler), this function only updates the timeout value
   that the custom busy handler reads. This preserves the ability to cancel
   busy waits via `cancel/1`.
+
+  A timeout of `0` makes lock contention fail immediately with `SQLITE_BUSY`.
+  Larger values let SQLite keep retrying until the timeout expires or the wait
+  is cancelled.
+
+  This is the low-level API behind the `:busy_timeout` connection option.
   """
   @spec set_busy_timeout(db(), integer()) :: :ok | {:error, reason()}
   def set_busy_timeout(conn, timeout_ms),
@@ -115,9 +126,14 @@ defmodule Exqlite.Sqlite3 do
   @doc """
   Configure how often SQLite invokes the progress handler during statement execution.
 
+  The default is `1000` virtual machine steps.
+
   Values less than `1` disable the progress handler. Larger values reduce the
   overhead of cancellation checks at the cost of slower response to `cancel/1`
   and `interrupt/1` while a query is running.
+
+  This is the low-level API behind the `:progress_handler_steps` connection
+  option.
   """
   @spec set_progress_handler_steps(db(), integer()) :: :ok | {:error, reason()}
   def set_progress_handler_steps(conn, steps),
@@ -129,6 +145,9 @@ defmodule Exqlite.Sqlite3 do
   This is a superset of `interrupt/1` — it sets a cancel flag that the busy and
   progress handlers observe, and also calls `sqlite3_interrupt()`. After a
   cancel, the connection can be reused normally.
+
+  Use this when a query might be blocked either inside SQLite bytecode
+  execution or inside the busy handler waiting for a lock.
   """
   @spec cancel(db() | nil) :: :ok | {:error, reason()}
   def cancel(nil), do: :ok

--- a/lib/exqlite/sqlite3.ex
+++ b/lib/exqlite/sqlite3.ex
@@ -113,11 +113,22 @@ defmodule Exqlite.Sqlite3 do
     do: Sqlite3NIF.set_busy_timeout(conn, timeout_ms)
 
   @doc """
+  Configure how often SQLite invokes the progress handler during statement execution.
+
+  Values less than `1` disable the progress handler. Larger values reduce the
+  overhead of cancellation checks at the cost of slower response to `cancel/1`
+  and `interrupt/1` while a query is running.
+  """
+  @spec set_progress_handler_steps(db(), integer()) :: :ok | {:error, reason()}
+  def set_progress_handler_steps(conn, steps),
+    do: Sqlite3NIF.set_progress_handler_steps(conn, steps)
+
+  @doc """
   Cancel a running query: wake any busy handler sleep and interrupt VDBE execution.
 
-  This is a superset of `interrupt/1` — it sets a cancel flag, signals the
-  condvar to wake any busy handler sleep, AND calls `sqlite3_interrupt()`.
-  After a cancel, the connection can be reused normally.
+  This is a superset of `interrupt/1` — it sets a cancel flag that the busy and
+  progress handlers observe, and also calls `sqlite3_interrupt()`. After a
+  cancel, the connection can be reused normally.
   """
   @spec cancel(db() | nil) :: :ok | {:error, reason()}
   def cancel(nil), do: :ok

--- a/lib/exqlite/sqlite3_nif.ex
+++ b/lib/exqlite/sqlite3_nif.ex
@@ -4,6 +4,12 @@ defmodule Exqlite.Sqlite3NIF do
   should be avoided unless you are aware of what you are doing.
   """
 
+  # Track C source files so Mix recompiles when they change
+  @external_resource "c_src/sqlite3_nif.c"
+  @external_resource "c_src/sqlite3.c"
+  @external_resource "c_src/sqlite3.h"
+  @external_resource "c_src/sqlite3ext.h"
+
   @compile {:autoload, false}
   @on_load {:load_nif, 0}
 

--- a/lib/exqlite/sqlite3_nif.ex
+++ b/lib/exqlite/sqlite3_nif.ex
@@ -35,6 +35,9 @@ defmodule Exqlite.Sqlite3NIF do
   @spec set_busy_timeout(db(), integer()) :: :ok | {:error, reason()}
   def set_busy_timeout(_conn, _timeout_ms), do: :erlang.nif_error(:not_loaded)
 
+  @spec set_progress_handler_steps(db(), integer()) :: :ok | {:error, reason()}
+  def set_progress_handler_steps(_conn, _steps), do: :erlang.nif_error(:not_loaded)
+
   @spec cancel(db()) :: :ok | {:error, reason()}
   def cancel(_conn), do: :erlang.nif_error(:not_loaded)
 

--- a/lib/exqlite/sqlite3_nif.ex
+++ b/lib/exqlite/sqlite3_nif.ex
@@ -26,6 +26,12 @@ defmodule Exqlite.Sqlite3NIF do
   @spec interrupt(db()) :: :ok | {:error, reason()}
   def interrupt(_conn), do: :erlang.nif_error(:not_loaded)
 
+  @spec set_busy_timeout(db(), integer()) :: :ok | {:error, reason()}
+  def set_busy_timeout(_conn, _timeout_ms), do: :erlang.nif_error(:not_loaded)
+
+  @spec cancel(db()) :: :ok | {:error, reason()}
+  def cancel(_conn), do: :erlang.nif_error(:not_loaded)
+
   @spec execute(db(), String.t()) :: :ok | {:error, reason()}
   def execute(_conn, _sql), do: :erlang.nif_error(:not_loaded)
 
@@ -72,10 +78,11 @@ defmodule Exqlite.Sqlite3NIF do
   @spec set_log_hook(pid()) :: :ok | {:error, reason()}
   def set_log_hook(_pid), do: :erlang.nif_error(:not_loaded)
 
-  @spec bind_parameter_count(statement) :: integer
+  @spec bind_parameter_count(statement) :: non_neg_integer() | {:error, reason()}
   def bind_parameter_count(_stmt), do: :erlang.nif_error(:not_loaded)
 
-  @spec bind_parameter_index(statement, String.t()) :: integer
+  @spec bind_parameter_index(statement, String.t()) ::
+          non_neg_integer() | {:error, reason()}
   def bind_parameter_index(_stmt, _name), do: :erlang.nif_error(:not_loaded)
 
   @spec bind_text(statement, non_neg_integer, String.t()) :: integer()

--- a/lib/exqlite/sqlite3_nif.ex
+++ b/lib/exqlite/sqlite3_nif.ex
@@ -87,8 +87,7 @@ defmodule Exqlite.Sqlite3NIF do
   @spec bind_parameter_count(statement) :: non_neg_integer() | {:error, reason()}
   def bind_parameter_count(_stmt), do: :erlang.nif_error(:not_loaded)
 
-  @spec bind_parameter_index(statement, String.t()) ::
-          non_neg_integer() | {:error, reason()}
+  @spec bind_parameter_index(statement, String.t()) :: non_neg_integer()
   def bind_parameter_index(_stmt, _name), do: :erlang.nif_error(:not_loaded)
 
   @spec bind_text(statement, non_neg_integer, String.t()) :: integer()

--- a/test/exqlite/cancellation_test.exs
+++ b/test/exqlite/cancellation_test.exs
@@ -1,0 +1,633 @@
+defmodule Exqlite.CancellationTest do
+  @moduledoc """
+  Tests for query cancellation and deadlock prevention (issue #192).
+
+  Validates that queries can be cancelled in flight and that disconnect
+  properly interrupts stuck queries to prevent pool deadlocks.
+  """
+
+  use ExUnit.Case
+
+  alias Exqlite.Sqlite3
+
+  @moduletag :slow_test
+
+  @long_running_select """
+  WITH RECURSIVE r(i) AS (
+    VALUES(0) UNION ALL SELECT i FROM r LIMIT 1000000000
+  ) SELECT i FROM r WHERE i = 1;
+  """
+
+  @long_running_insert """
+  WITH RECURSIVE r(i) AS (
+    VALUES(0) UNION ALL SELECT i+1 FROM r LIMIT 1000000000
+  ) INSERT INTO t SELECT i FROM r;
+  """
+
+  defp with_db(fun), do: with_db(":memory:", fun)
+
+  defp with_db(path, fun) do
+    {:ok, db} = Sqlite3.open(path)
+
+    try do
+      fun.(db)
+    after
+      Sqlite3.close(db)
+    end
+  end
+
+  defp with_file_db(fun) do
+    path = Temp.path!()
+
+    try do
+      fun.(path)
+    after
+      File.rm(path)
+      File.rm(path <> "-wal")
+      File.rm(path <> "-shm")
+    end
+  end
+
+  defp interrupt_long_query(db, query, opts \\ []) do
+    delay = Keyword.get(opts, :delay, 200)
+    parent = self()
+
+    spawn(fn ->
+      result =
+        case Keyword.get(opts, :mode, :multi_step) do
+          :multi_step ->
+            {:ok, stmt} = Sqlite3.prepare(db, query)
+            Sqlite3.multi_step(db, stmt, 50)
+
+          :execute ->
+            Sqlite3.execute(db, query)
+        end
+
+      send(parent, {:query_result, result})
+    end)
+
+    Process.sleep(delay)
+    :ok = Sqlite3.interrupt(db)
+
+    receive do
+      {:query_result, result} -> result
+    after
+      5_000 -> flunk("query did not return within 5s after interrupt")
+    end
+  end
+
+  # -- Interrupt basics -------------------------------------------------------
+
+  describe "interrupt" do
+    test "aborts a long-running SELECT via multi_step" do
+      with_db(fn db ->
+        assert {:error, _} = interrupt_long_query(db, @long_running_select)
+      end)
+    end
+
+    test "aborts a long-running SELECT via execute" do
+      with_db(fn db ->
+        assert {:error, _} =
+                 interrupt_long_query(db, @long_running_select, mode: :execute)
+      end)
+    end
+
+    test "aborts a long-running INSERT" do
+      with_db(fn db ->
+        :ok = Sqlite3.execute(db, "CREATE TABLE t (i INTEGER)")
+
+        assert {:error, _} =
+                 interrupt_long_query(db, @long_running_insert, mode: :execute)
+      end)
+    end
+
+    test "interrupt latency is under 2 seconds" do
+      with_db(fn db ->
+        {:ok, stmt} = Sqlite3.prepare(db, @long_running_select)
+        parent = self()
+
+        spawn(fn ->
+          result = Sqlite3.multi_step(db, stmt, 50)
+          send(parent, {:query_result, result})
+        end)
+
+        Process.sleep(200)
+        t0 = System.monotonic_time(:millisecond)
+        :ok = Sqlite3.interrupt(db)
+        assert_receive {:query_result, {:error, _}}, 5_000
+        assert System.monotonic_time(:millisecond) - t0 < 2_000
+      end)
+    end
+
+    test "has no effect when called before a query starts" do
+      with_db(fn db ->
+        :ok = Sqlite3.execute(db, "CREATE TABLE t (x INTEGER)")
+        :ok = Sqlite3.execute(db, "INSERT INTO t VALUES(42)")
+
+        :ok = Sqlite3.interrupt(db)
+
+        {:ok, stmt} = Sqlite3.prepare(db, "SELECT x FROM t")
+        assert {:done, [[42]]} = Sqlite3.multi_step(db, stmt, 50)
+      end)
+    end
+  end
+
+  # -- Connection state after interrupt ----------------------------------------
+
+  describe "connection after interrupt" do
+    test "is still usable for new queries" do
+      with_db(fn db ->
+        :ok = Sqlite3.execute(db, "CREATE TABLE t (x INTEGER)")
+        :ok = Sqlite3.execute(db, "INSERT INTO t VALUES(42)")
+
+        {:error, _} = interrupt_long_query(db, @long_running_select)
+
+        {:ok, stmt} = Sqlite3.prepare(db, "SELECT x FROM t")
+        assert {:done, [[42]]} = Sqlite3.multi_step(db, stmt, 50)
+      end)
+    end
+
+    test "survives 10 consecutive interrupt cycles" do
+      with_db(fn db ->
+        :ok = Sqlite3.execute(db, "CREATE TABLE t (x INTEGER)")
+        :ok = Sqlite3.execute(db, "INSERT INTO t VALUES(1)")
+
+        for _cycle <- 1..10 do
+          {:error, _} = interrupt_long_query(db, @long_running_select, delay: 50)
+        end
+
+        {:ok, stmt} = Sqlite3.prepare(db, "SELECT x FROM t")
+        assert {:done, [[1]]} = Sqlite3.multi_step(db, stmt, 50)
+      end)
+    end
+
+    test "interrupted write inside BEGIN leaves transaction rollback-able" do
+      with_db(fn db ->
+        :ok = Sqlite3.execute(db, "CREATE TABLE t (i INTEGER)")
+        :ok = Sqlite3.execute(db, "INSERT INTO t VALUES(1)")
+        :ok = Sqlite3.execute(db, "BEGIN IMMEDIATE")
+
+        {:error, _} = interrupt_long_query(db, @long_running_insert, mode: :execute)
+
+        {:ok, status} = Sqlite3.transaction_status(db)
+
+        case status do
+          :transaction -> :ok = Sqlite3.execute(db, "ROLLBACK")
+          :idle -> :ok
+        end
+
+        {:ok, stmt} = Sqlite3.prepare(db, "SELECT count(*) FROM t")
+        assert {:done, [[1]]} = Sqlite3.multi_step(db, stmt, 50)
+      end)
+    end
+  end
+
+  # -- Interrupt + close race (PR #342 validation) ----------------------------
+
+  describe "interrupt + close race safety" do
+    test "100 cycles of query/interrupt/close/reopen" do
+      for cycle <- 1..100 do
+        {:ok, db} = Sqlite3.open(":memory:")
+        parent = self()
+
+        spawn(fn ->
+          {:ok, stmt} = Sqlite3.prepare(db, @long_running_select)
+          result = Sqlite3.multi_step(db, stmt, 50)
+          send(parent, {:done, result})
+        end)
+
+        Process.sleep(10)
+        :ok = Sqlite3.interrupt(db)
+
+        receive do
+          {:done, _} -> :ok
+        after
+          5_000 -> flunk("cycle #{cycle}: query did not return after interrupt")
+        end
+
+        :ok = Sqlite3.close(db)
+      end
+    end
+  end
+
+  # -- Busy handler vs interrupt -----------------------------------------------
+
+  describe "interrupt vs busy handler" do
+    test "interrupt does NOT break through busy handler sleep" do
+      with_file_db(fn path ->
+        {:ok, db1} = Sqlite3.open(path)
+        {:ok, db2} = Sqlite3.open(path)
+
+        :ok = Sqlite3.execute(db1, "PRAGMA journal_mode=WAL")
+        :ok = Sqlite3.execute(db1, "CREATE TABLE t (i INTEGER)")
+        :ok = Sqlite3.execute(db1, "INSERT INTO t VALUES(1)")
+        :ok = Sqlite3.set_busy_timeout(db2, 30_000)
+
+        # db1 holds an exclusive write lock
+        :ok = Sqlite3.execute(db1, "BEGIN IMMEDIATE")
+        :ok = Sqlite3.execute(db1, "INSERT INTO t VALUES(2)")
+
+        parent = self()
+
+        # db2 tries to write — enters busy handler sleep loop
+        spawn(fn ->
+          result = Sqlite3.execute(db2, "BEGIN IMMEDIATE")
+          send(parent, {:db2_result, result})
+        end)
+
+        Process.sleep(500)
+        :ok = Sqlite3.interrupt(db2)
+
+        # db2 should NOT return within 5s — interrupt doesn't affect busy handler
+        got_response =
+          receive do
+            {:db2_result, _} -> true
+          after
+            5_000 -> false
+          end
+
+        # Release the lock so db2 can finish
+        Sqlite3.execute(db1, "ROLLBACK")
+
+        unless got_response do
+          receive do
+            {:db2_result, _} -> :ok
+          after
+            35_000 -> :ok
+          end
+        end
+
+        Sqlite3.close(db1)
+        Sqlite3.close(db2)
+
+        refute got_response,
+               "interrupt broke through busy handler — expected it to stay blocked"
+      end)
+    end
+  end
+
+  # -- Concurrent reads on single connection -----------------------------------
+
+  describe "concurrent reads on single connection" do
+    test "20 concurrent readers all get correct results" do
+      with_db(fn db ->
+        :ok = Sqlite3.execute(db, "CREATE TABLE t (id INTEGER PRIMARY KEY)")
+
+        for i <- 1..100 do
+          :ok = Sqlite3.execute(db, "INSERT INTO t VALUES(#{i})")
+        end
+
+        parent = self()
+
+        for idx <- 1..20 do
+          spawn(fn ->
+            {:ok, stmt} = Sqlite3.prepare(db, "SELECT count(*) FROM t")
+            result = Sqlite3.multi_step(db, stmt, 50)
+            send(parent, {:reader, idx, result})
+          end)
+        end
+
+        for _ <- 1..20 do
+          assert_receive {:reader, _idx, {:done, [[100]]}}, 10_000
+        end
+      end)
+    end
+  end
+
+  # -- Single-connection isolation ---------------------------------------------
+
+  describe "single-connection isolation" do
+    test "reads see own uncommitted writes" do
+      with_db(fn db ->
+        :ok = Sqlite3.execute(db, "CREATE TABLE t (x INTEGER)")
+        :ok = Sqlite3.execute(db, "INSERT INTO t VALUES(1)")
+
+        :ok = Sqlite3.execute(db, "BEGIN")
+        :ok = Sqlite3.execute(db, "INSERT INTO t VALUES(2)")
+
+        {:ok, stmt} = Sqlite3.prepare(db, "SELECT count(*) FROM t")
+        {:done, [[count]]} = Sqlite3.multi_step(db, stmt, 50)
+
+        assert count == 2
+        :ok = Sqlite3.execute(db, "ROLLBACK")
+      end)
+    end
+  end
+
+  # -- Implicit transaction staleness (two connections, WAL) -------------------
+
+  describe "implicit transaction staleness" do
+    test "completed statement allows reader to see new data" do
+      with_file_db(fn path ->
+        {:ok, writer} = Sqlite3.open(path)
+        {:ok, reader} = Sqlite3.open(path)
+
+        :ok = Sqlite3.execute(writer, "PRAGMA journal_mode=WAL")
+        :ok = Sqlite3.execute(writer, "CREATE TABLE t (i INTEGER)")
+        :ok = Sqlite3.execute(writer, "INSERT INTO t VALUES(1)")
+
+        {:ok, stmt1} = Sqlite3.prepare(reader, "SELECT * FROM t")
+        {:done, [[1]]} = Sqlite3.multi_step(reader, stmt1, 50)
+
+        :ok = Sqlite3.execute(writer, "INSERT INTO t VALUES(2)")
+
+        {:ok, stmt2} = Sqlite3.prepare(reader, "SELECT count(*) FROM t")
+        {:done, [[count]]} = Sqlite3.multi_step(reader, stmt2, 50)
+        assert count == 2
+
+        Sqlite3.close(writer)
+        Sqlite3.close(reader)
+      end)
+    end
+
+    test "in-progress statement keeps reader on stale snapshot" do
+      with_file_db(fn path ->
+        {:ok, writer} = Sqlite3.open(path)
+        {:ok, reader} = Sqlite3.open(path)
+
+        :ok = Sqlite3.execute(writer, "PRAGMA journal_mode=WAL")
+        :ok = Sqlite3.execute(writer, "CREATE TABLE t (i INTEGER)")
+        for i <- 1..10, do: Sqlite3.execute(writer, "INSERT INTO t VALUES(#{i})")
+
+        # Step partially — implicit read tx still open
+        {:ok, stmt1} = Sqlite3.prepare(reader, "SELECT * FROM t")
+        {:rows, _partial} = Sqlite3.multi_step(reader, stmt1, 3)
+
+        :ok = Sqlite3.execute(writer, "INSERT INTO t VALUES(99)")
+
+        {:ok, stmt2} = Sqlite3.prepare(reader, "SELECT count(*) FROM t")
+        {:done, [[count_stale]]} = Sqlite3.multi_step(reader, stmt2, 50)
+        assert count_stale == 10
+
+        # Finish stmt1
+        _rest = Sqlite3.multi_step(reader, stmt1, 50)
+
+        {:ok, stmt3} = Sqlite3.prepare(reader, "SELECT count(*) FROM t")
+        {:done, [[count_fresh]]} = Sqlite3.multi_step(reader, stmt3, 50)
+        assert count_fresh == 11
+
+        Sqlite3.close(writer)
+        Sqlite3.close(reader)
+      end)
+    end
+  end
+
+  # -- Close blocks on mutex ---------------------------------------------------
+
+  describe "close vs running query" do
+    test "close blocks until interrupt releases the mutex" do
+      {:ok, db} = Sqlite3.open(":memory:")
+      {:ok, stmt} = Sqlite3.prepare(db, @long_running_select)
+      parent = self()
+
+      spawn(fn ->
+        result = Sqlite3.multi_step(db, stmt, 50)
+        send(parent, {:query_done, result})
+      end)
+
+      Process.sleep(200)
+
+      spawn(fn ->
+        result = Sqlite3.close(db)
+        send(parent, {:close_done, result})
+      end)
+
+      # Close should NOT return yet — it's blocked on the mutex
+      refute_receive {:close_done, _}, 500
+
+      :ok = Sqlite3.interrupt(db)
+
+      assert_receive {:query_done, {:error, _}}, 5_000
+      assert_receive {:close_done, :ok}, 5_000
+    end
+  end
+
+  # -- WAL concurrent access patterns -----------------------------------------
+
+  describe "WAL mode" do
+    test "concurrent reads from two connections succeed" do
+      with_file_db(fn path ->
+        {:ok, db1} = Sqlite3.open(path)
+        {:ok, db2} = Sqlite3.open(path)
+
+        :ok = Sqlite3.execute(db1, "PRAGMA journal_mode=WAL")
+        :ok = Sqlite3.execute(db1, "CREATE TABLE t (i INTEGER)")
+        for i <- 1..100, do: Sqlite3.execute(db1, "INSERT INTO t VALUES(#{i})")
+
+        {:ok, s1} = Sqlite3.prepare(db1, "SELECT count(*) FROM t")
+        {:ok, s2} = Sqlite3.prepare(db2, "SELECT count(*) FROM t")
+
+        assert {:done, [[100]]} = Sqlite3.multi_step(db1, s1, 50)
+        assert {:done, [[100]]} = Sqlite3.multi_step(db2, s2, 50)
+
+        Sqlite3.close(db1)
+        Sqlite3.close(db2)
+      end)
+    end
+
+    test "second writer gets SQLITE_BUSY with busy_timeout=0" do
+      with_file_db(fn path ->
+        {:ok, db1} = Sqlite3.open(path)
+        {:ok, db2} = Sqlite3.open(path)
+
+        :ok = Sqlite3.execute(db1, "PRAGMA journal_mode=WAL")
+        :ok = Sqlite3.execute(db2, "PRAGMA journal_mode=WAL")
+        :ok = Sqlite3.set_busy_timeout(db1, 0)
+        :ok = Sqlite3.set_busy_timeout(db2, 0)
+        :ok = Sqlite3.execute(db1, "CREATE TABLE t (i INTEGER)")
+
+        :ok = Sqlite3.execute(db1, "BEGIN IMMEDIATE")
+        :ok = Sqlite3.execute(db1, "INSERT INTO t VALUES(1)")
+
+        assert {:error, _} = Sqlite3.execute(db2, "BEGIN IMMEDIATE")
+
+        Sqlite3.execute(db1, "ROLLBACK")
+        Sqlite3.close(db1)
+        Sqlite3.close(db2)
+      end)
+    end
+
+    test "deferred read tx conflicts with concurrent write" do
+      with_file_db(fn path ->
+        {:ok, c1} = Sqlite3.open(path)
+        {:ok, c2} = Sqlite3.open(path)
+
+        :ok = Sqlite3.execute(c1, "PRAGMA journal_mode=WAL")
+        :ok = Sqlite3.set_busy_timeout(c1, 0)
+        :ok = Sqlite3.set_busy_timeout(c2, 0)
+        :ok = Sqlite3.execute(c1, "CREATE TABLE t (i INTEGER)")
+        :ok = Sqlite3.execute(c1, "INSERT INTO t VALUES(1)")
+
+        :ok = Sqlite3.execute(c1, "BEGIN")
+        {:ok, stmt} = Sqlite3.prepare(c1, "SELECT * FROM t")
+        {:done, [[1]]} = Sqlite3.multi_step(c1, stmt, 50)
+
+        :ok = Sqlite3.execute(c2, "DELETE FROM t WHERE i = 1")
+
+        assert {:error, _} = Sqlite3.execute(c1, "INSERT INTO t VALUES(2)")
+
+        Sqlite3.execute(c1, "ROLLBACK")
+        Sqlite3.close(c1)
+        Sqlite3.close(c2)
+      end)
+    end
+  end
+
+  # -- DBConnection pool recovery after timeout --------------------------------
+
+  describe "DBConnection timeout recovery" do
+    @tag timeout: 30_000
+    test "pool recovers after a long query is interrupted on disconnect" do
+      with_file_db(fn path ->
+        {:ok, conn} =
+          Exqlite.start_link(
+            database: path,
+            journal_mode: :wal,
+            timeout: 1_000,
+            busy_timeout: 0,
+            pool_size: 1
+          )
+
+        Exqlite.query!(conn, "CREATE TABLE t (i INTEGER)", [])
+        Exqlite.query!(conn, "INSERT INTO t VALUES(1)", [])
+
+        # The long query should be interrupted when DBConnection's timeout
+        # triggers a disconnect, which now calls Sqlite3.cancel/1.
+        result =
+          try do
+            Exqlite.query(conn, @long_running_select, [], timeout: 1_000)
+          rescue
+            e -> {:exception, e}
+          catch
+            :exit, reason -> {:exit, reason}
+          end
+
+        assert match?({:exit, _}, result) or match?({:error, _}, result)
+
+        # Pool should recover — next query should work
+        assert {:ok, %Exqlite.Result{rows: [[1]]}} =
+                 Exqlite.query(conn, "SELECT count(*) FROM t", [], timeout: 5_000)
+
+        GenServer.stop(conn, :normal, 5_000)
+      end)
+    end
+
+    @tag timeout: 30_000
+    test "pool recovers when query is stuck in busy handler" do
+      with_file_db(fn path ->
+        # Open a raw connection that will hold an exclusive lock
+        {:ok, blocker} = Sqlite3.open(path)
+        :ok = Sqlite3.execute(blocker, "PRAGMA journal_mode=WAL")
+        :ok = Sqlite3.execute(blocker, "CREATE TABLE t (i INTEGER)")
+        :ok = Sqlite3.execute(blocker, "INSERT INTO t VALUES(1)")
+
+        # Pool connection gets a long busy_timeout so it enters the sleep loop
+        {:ok, conn} =
+          Exqlite.start_link(
+            database: path,
+            journal_mode: :wal,
+            timeout: 2_000,
+            busy_timeout: 60_000,
+            pool_size: 1
+          )
+
+        # Blocker grabs exclusive write lock
+        :ok = Sqlite3.execute(blocker, "BEGIN IMMEDIATE")
+        :ok = Sqlite3.execute(blocker, "INSERT INTO t VALUES(2)")
+
+        parent = self()
+
+        # Pool tries to write — enters busy handler sleep loop waiting for lock
+        spawn(fn ->
+          result =
+            try do
+              Exqlite.query(conn, "INSERT INTO t VALUES(3)", [], timeout: 2_000)
+            rescue
+              e -> {:exception, e}
+            catch
+              :exit, reason -> {:exit, reason}
+            end
+
+          send(parent, {:pool_result, result})
+        end)
+
+        # The pool query should return within 15s because disconnect calls
+        # cancel(), which breaks through the busy handler sleep loop
+        # (the fix for issue #192).
+        pool_returned =
+          receive do
+            {:pool_result, _result} -> true
+          after
+            15_000 -> false
+          end
+
+        # Release the lock so everything can unwind
+        Sqlite3.execute(blocker, "ROLLBACK")
+
+        unless pool_returned do
+          receive do
+            {:pool_result, _} -> :ok
+          after
+            65_000 -> :ok
+          end
+        end
+
+        Sqlite3.close(blocker)
+
+        assert pool_returned,
+               "Pool is stuck in busy handler — disconnect needs a custom busy handler to fix this"
+      end)
+    end
+  end
+
+  # -- Watchdog pattern --------------------------------------------------------
+
+  describe "watchdog pattern" do
+    test "auto-interrupts a query after a timeout" do
+      with_db(fn db ->
+        {:ok, stmt} = Sqlite3.prepare(db, @long_running_select)
+        timeout_ms = 500
+
+        watchdog =
+          spawn(fn ->
+            receive do
+              :cancel -> :ok
+            after
+              timeout_ms -> Sqlite3.interrupt(db)
+            end
+          end)
+
+        {elapsed_us, result} =
+          :timer.tc(fn -> Sqlite3.multi_step(db, stmt, 50) end)
+
+        send(watchdog, :cancel)
+
+        assert {:error, _} = result
+        assert div(elapsed_us, 1000) < timeout_ms + 2_000
+      end)
+    end
+
+    test "cancelling the watchdog lets the query complete normally" do
+      with_db(fn db ->
+        :ok = Sqlite3.execute(db, "CREATE TABLE t (x INTEGER)")
+        :ok = Sqlite3.execute(db, "INSERT INTO t VALUES(1)")
+
+        {:ok, stmt} = Sqlite3.prepare(db, "SELECT x FROM t")
+
+        watchdog =
+          spawn(fn ->
+            receive do
+              :cancel -> :ok
+            after
+              5_000 -> Sqlite3.interrupt(db)
+            end
+          end)
+
+        result = Sqlite3.multi_step(db, stmt, 50)
+        send(watchdog, :cancel)
+
+        assert {:done, [[1]]} = result
+      end)
+    end
+  end
+end

--- a/test/exqlite/integration_test.exs
+++ b/test/exqlite/integration_test.exs
@@ -244,8 +244,12 @@ defmodule Exqlite.IntegrationTest do
     # interrupts running queries via the progress handler. So a query that
     # exceeds the checkout timeout may be interrupted rather than completing.
     case DBConnection.execute(conn, query, [], timeout: 1) do
-      {:ok, _, _} -> :ok
-      {:error, %Exqlite.Error{message: "interrupted"}} -> :ok
+      {:ok, _, _} ->
+        :ok
+
+      {:error, %Exqlite.Error{message: "interrupted"}} ->
+        :ok
+
       {:error, %Exqlite.Error{message: msg}} ->
         flunk("Unexpected error while executing query: #{msg}")
     end

--- a/test/exqlite/integration_test.exs
+++ b/test/exqlite/integration_test.exs
@@ -246,7 +246,8 @@ defmodule Exqlite.IntegrationTest do
     case DBConnection.execute(conn, query, [], timeout: 1) do
       {:ok, _, _} -> :ok
       {:error, %Exqlite.Error{message: "interrupted"}} -> :ok
-      {:error, %Exqlite.Error{message: "out of memory"}} -> :ok
+      {:error, %Exqlite.Error{message: msg}} ->
+        flunk("Unexpected error while executing query: #{msg}")
     end
 
     File.rm(path)

--- a/test/exqlite/integration_test.exs
+++ b/test/exqlite/integration_test.exs
@@ -243,16 +243,13 @@ defmodule Exqlite.IntegrationTest do
     # With the cancellable busy handler (issue #192), disconnect now properly
     # interrupts running queries via the progress handler. So a query that
     # exceeds the checkout timeout may be interrupted rather than completing.
-    # With a 1ms timeout the disconnect can race mid-allocation, so SQLite may
-    # also return SQLITE_NOMEM before the interrupt lands — that's expected here.
-    case DBConnection.execute(conn, query, [], timeout: 1) do
+    # Use a small but non-trivial timeout so the disconnect lands during query
+    # execution without racing SQLite's initial row allocation path.
+    case DBConnection.execute(conn, query, [], timeout: 10) do
       {:ok, _, _} ->
         :ok
 
       {:error, %Exqlite.Error{message: "interrupted"}} ->
-        :ok
-
-      {:error, %Exqlite.Error{message: "out of memory"}} ->
         :ok
 
       {:error, %Exqlite.Error{message: msg}} ->

--- a/test/exqlite/sanitizer_test.exs
+++ b/test/exqlite/sanitizer_test.exs
@@ -1,0 +1,110 @@
+defmodule Exqlite.SanitizerTest do
+  use ExUnit.Case
+
+  alias Exqlite.Sqlite3
+
+  @moduletag :sanitizer
+
+  defp with_file_db(fun) do
+    path = Temp.path!()
+
+    try do
+      fun.(path)
+    after
+      File.rm(path)
+      File.rm(path <> "-wal")
+      File.rm(path <> "-shm")
+    end
+  end
+
+  test "busy handler cancellation is sanitizer-clean" do
+    with_file_db(fn path ->
+      {:ok, db1} = Sqlite3.open(path)
+      {:ok, db2} = Sqlite3.open(path)
+
+      try do
+        :ok = Sqlite3.execute(db1, "PRAGMA journal_mode=WAL")
+        :ok = Sqlite3.execute(db1, "CREATE TABLE t (i INTEGER)")
+        :ok = Sqlite3.execute(db1, "INSERT INTO t VALUES(1)")
+        :ok = Sqlite3.set_busy_timeout(db2, 60_000)
+        :ok = Sqlite3.set_progress_handler_steps(db2, -1)
+
+        :ok = Sqlite3.execute(db1, "BEGIN IMMEDIATE")
+        :ok = Sqlite3.execute(db1, "INSERT INTO t VALUES(2)")
+
+        parent = self()
+
+        writer =
+          spawn(fn ->
+            result = Sqlite3.execute(db2, "INSERT INTO t VALUES(3)")
+            send(parent, {:writer_done, result})
+          end)
+
+        Process.sleep(100)
+
+        canceller =
+          Task.async(fn ->
+            for _ <- 1..200 do
+              Sqlite3.cancel(db2)
+              Process.sleep(1)
+            end
+          end)
+
+        assert_receive {:writer_done, {:error, _}}, 5_000
+        Task.await(canceller, 5_000)
+        refute Process.alive?(writer)
+      after
+        Sqlite3.execute(db1, "ROLLBACK")
+        Sqlite3.close(db1)
+        Sqlite3.close(db2)
+      end
+    end)
+  end
+
+  test "busy timeout updates during contention are sanitizer-clean" do
+    with_file_db(fn path ->
+      {:ok, db1} = Sqlite3.open(path)
+      {:ok, db2} = Sqlite3.open(path)
+
+      try do
+        :ok = Sqlite3.execute(db1, "PRAGMA journal_mode=WAL")
+        :ok = Sqlite3.execute(db1, "CREATE TABLE t (i INTEGER)")
+        :ok = Sqlite3.execute(db1, "INSERT INTO t VALUES(1)")
+        :ok = Sqlite3.set_busy_timeout(db2, 60_000)
+        :ok = Sqlite3.set_progress_handler_steps(db2, -1)
+
+        :ok = Sqlite3.execute(db1, "BEGIN IMMEDIATE")
+        :ok = Sqlite3.execute(db1, "INSERT INTO t VALUES(2)")
+
+        parent = self()
+
+        writer =
+          spawn(fn ->
+            result = Sqlite3.execute(db2, "INSERT INTO t VALUES(3)")
+            send(parent, {:writer_done, result})
+          end)
+
+        Process.sleep(100)
+
+        updater =
+          Task.async(fn ->
+            for timeout_ms <- Stream.cycle([0, 1, 5, 25, 250, 5_000]) |> Enum.take(500) do
+              result = Sqlite3.set_busy_timeout(db2, timeout_ms)
+              if result not in [:ok, {:error, :connection_closed}], do: flunk("unexpected result")
+            end
+          end)
+
+        Process.sleep(50)
+        :ok = Sqlite3.cancel(db2)
+
+        assert_receive {:writer_done, {:error, _}}, 5_000
+        Task.await(updater, 5_000)
+        refute Process.alive?(writer)
+      after
+        Sqlite3.execute(db1, "ROLLBACK")
+        Sqlite3.close(db1)
+        Sqlite3.close(db2)
+      end
+    end)
+  end
+end

--- a/test/exqlite/sanitizer_test.exs
+++ b/test/exqlite/sanitizer_test.exs
@@ -90,7 +90,9 @@ defmodule Exqlite.SanitizerTest do
           Task.async(fn ->
             for timeout_ms <- Stream.cycle([0, 1, 5, 25, 250, 5_000]) |> Enum.take(500) do
               result = Sqlite3.set_busy_timeout(db2, timeout_ms)
-              if result not in [:ok, {:error, :connection_closed}], do: flunk("unexpected result")
+
+              if result not in [:ok, {:error, :connection_closed}],
+                do: flunk("unexpected result")
             end
           end)
 

--- a/test/exqlite/sqlite3_test.exs
+++ b/test/exqlite/sqlite3_test.exs
@@ -1221,4 +1221,290 @@ defmodule Exqlite.Sqlite3Test do
       end
     end
   end
+
+  # -- Busy timeout baseline behavior ------------------------------------------
+
+  describe "busy_timeout behavior" do
+    defp with_file_db(fun) do
+      path = Temp.path!()
+
+      try do
+        fun.(path)
+      after
+        File.rm(path)
+        File.rm(path <> "-wal")
+        File.rm(path <> "-shm")
+      end
+    end
+
+    defp setup_write_conflict(path, opts) do
+      busy_timeout = Keyword.get(opts, :busy_timeout, 2000)
+
+      {:ok, db1} = Sqlite3.open(path)
+      {:ok, db2} = Sqlite3.open(path)
+
+      :ok = Sqlite3.execute(db1, "PRAGMA journal_mode=WAL")
+      :ok = Sqlite3.execute(db1, "CREATE TABLE t (i INTEGER)")
+      :ok = Sqlite3.execute(db1, "INSERT INTO t VALUES(1)")
+
+      :ok = Sqlite3.set_busy_timeout(db2, busy_timeout)
+
+      # db1 grabs exclusive write lock
+      :ok = Sqlite3.execute(db1, "BEGIN IMMEDIATE")
+      :ok = Sqlite3.execute(db1, "INSERT INTO t VALUES(2)")
+
+      {db1, db2}
+    end
+
+    test "second writer waits ~busy_timeout before returning error" do
+      with_file_db(fn path ->
+        {db1, db2} = setup_write_conflict(path, busy_timeout: 500)
+
+        {elapsed_us, result} =
+          :timer.tc(fn -> Sqlite3.execute(db2, "INSERT INTO t VALUES(3)") end)
+
+        elapsed_ms = div(elapsed_us, 1000)
+
+        assert {:error, _msg} = result
+
+        assert elapsed_ms >= 300,
+               "returned too quickly (#{elapsed_ms}ms), expected ~500ms delay"
+
+        assert elapsed_ms < 3000, "took too long (#{elapsed_ms}ms)"
+
+        :ok = Sqlite3.execute(db1, "ROLLBACK")
+        Sqlite3.close(db1)
+        Sqlite3.close(db2)
+      end)
+    end
+
+    test "busy_timeout=0 returns error immediately" do
+      with_file_db(fn path ->
+        {db1, db2} = setup_write_conflict(path, busy_timeout: 0)
+
+        {elapsed_us, result} =
+          :timer.tc(fn -> Sqlite3.execute(db2, "INSERT INTO t VALUES(3)") end)
+
+        elapsed_ms = div(elapsed_us, 1000)
+
+        assert {:error, _msg} = result
+
+        assert elapsed_ms < 100,
+               "busy_timeout=0 should return immediately, took #{elapsed_ms}ms"
+
+        :ok = Sqlite3.execute(db1, "ROLLBACK")
+        Sqlite3.close(db1)
+        Sqlite3.close(db2)
+      end)
+    end
+
+    test "multi_step returns :busy on write conflict with timeout=0" do
+      with_file_db(fn path ->
+        {db1, db2} = setup_write_conflict(path, busy_timeout: 0)
+
+        {:ok, stmt} = Sqlite3.prepare(db2, "INSERT INTO t VALUES(3)")
+        result = Sqlite3.multi_step(db2, stmt, 1)
+
+        assert result == :busy
+
+        :ok = Sqlite3.execute(db1, "ROLLBACK")
+        Sqlite3.close(db1)
+        Sqlite3.close(db2)
+      end)
+    end
+
+    test "step returns :busy on write conflict with timeout=0" do
+      with_file_db(fn path ->
+        {db1, db2} = setup_write_conflict(path, busy_timeout: 0)
+
+        {:ok, stmt} = Sqlite3.prepare(db2, "INSERT INTO t VALUES(3)")
+        result = Sqlite3.step(db2, stmt)
+
+        assert result == :busy
+
+        :ok = Sqlite3.execute(db1, "ROLLBACK")
+        Sqlite3.close(db1)
+        Sqlite3.close(db2)
+      end)
+    end
+  end
+
+  # -- New NIF: set_busy_timeout/2 ---------------------------------------------
+
+  describe ".set_busy_timeout/2" do
+    test "sets busy timeout and returns :ok" do
+      {:ok, conn} = Sqlite3.open(":memory:")
+
+      assert :ok = Sqlite3.set_busy_timeout(conn, 5000)
+
+      Sqlite3.close(conn)
+    end
+
+    test "timeout of 0 causes immediate SQLITE_BUSY" do
+      with_file_db(fn path ->
+        {:ok, db1} = Sqlite3.open(path)
+        {:ok, db2} = Sqlite3.open(path)
+
+        :ok = Sqlite3.execute(db1, "PRAGMA journal_mode=WAL")
+        :ok = Sqlite3.execute(db1, "CREATE TABLE t (i INTEGER)")
+        :ok = Sqlite3.execute(db1, "INSERT INTO t VALUES(1)")
+
+        :ok = Sqlite3.set_busy_timeout(db2, 0)
+
+        :ok = Sqlite3.execute(db1, "BEGIN IMMEDIATE")
+        :ok = Sqlite3.execute(db1, "INSERT INTO t VALUES(2)")
+
+        {elapsed_us, result} =
+          :timer.tc(fn -> Sqlite3.execute(db2, "INSERT INTO t VALUES(3)") end)
+
+        elapsed_ms = div(elapsed_us, 1000)
+
+        assert {:error, _} = result
+        assert elapsed_ms < 100
+
+        :ok = Sqlite3.execute(db1, "ROLLBACK")
+        Sqlite3.close(db1)
+        Sqlite3.close(db2)
+      end)
+    end
+
+    test "custom timeout delays before SQLITE_BUSY" do
+      with_file_db(fn path ->
+        {:ok, db1} = Sqlite3.open(path)
+        {:ok, db2} = Sqlite3.open(path)
+
+        :ok = Sqlite3.execute(db1, "PRAGMA journal_mode=WAL")
+        :ok = Sqlite3.execute(db1, "CREATE TABLE t (i INTEGER)")
+        :ok = Sqlite3.execute(db1, "INSERT INTO t VALUES(1)")
+
+        :ok = Sqlite3.set_busy_timeout(db2, 500)
+
+        :ok = Sqlite3.execute(db1, "BEGIN IMMEDIATE")
+        :ok = Sqlite3.execute(db1, "INSERT INTO t VALUES(2)")
+
+        {elapsed_us, result} =
+          :timer.tc(fn -> Sqlite3.execute(db2, "INSERT INTO t VALUES(3)") end)
+
+        elapsed_ms = div(elapsed_us, 1000)
+
+        assert {:error, _} = result
+        assert elapsed_ms >= 300, "returned too quickly (#{elapsed_ms}ms)"
+        assert elapsed_ms < 3000, "took too long (#{elapsed_ms}ms)"
+
+        :ok = Sqlite3.execute(db1, "ROLLBACK")
+        Sqlite3.close(db1)
+        Sqlite3.close(db2)
+      end)
+    end
+  end
+
+  # -- New NIF: cancel/1 -------------------------------------------------------
+
+  describe ".cancel/1" do
+    test "returns :ok on an idle connection" do
+      {:ok, conn} = Sqlite3.open(":memory:")
+
+      assert :ok = Sqlite3.cancel(conn)
+
+      Sqlite3.close(conn)
+    end
+
+    test "breaks through busy handler sleep" do
+      with_file_db(fn path ->
+        {:ok, db1} = Sqlite3.open(path)
+        {:ok, db2} = Sqlite3.open(path)
+
+        :ok = Sqlite3.execute(db1, "PRAGMA journal_mode=WAL")
+        :ok = Sqlite3.execute(db1, "CREATE TABLE t (i INTEGER)")
+        :ok = Sqlite3.execute(db1, "INSERT INTO t VALUES(1)")
+
+        # db2 gets a long busy timeout — without cancel, it would wait 60s
+        :ok = Sqlite3.set_busy_timeout(db2, 60_000)
+
+        # db1 holds exclusive lock
+        :ok = Sqlite3.execute(db1, "BEGIN IMMEDIATE")
+        :ok = Sqlite3.execute(db1, "INSERT INTO t VALUES(2)")
+
+        parent = self()
+
+        # db2 tries to write — enters busy handler sleep
+        spawn(fn ->
+          result = Sqlite3.execute(db2, "INSERT INTO t VALUES(3)")
+          send(parent, {:write_result, result})
+        end)
+
+        # Give it time to enter the busy handler
+        Process.sleep(200)
+
+        # Cancel should wake the busy handler immediately
+        :ok = Sqlite3.cancel(db2)
+
+        result =
+          receive do
+            {:write_result, r} -> r
+          after
+            2_000 -> :timeout
+          end
+
+        assert result != :timeout,
+               "cancel did not break through busy handler within 2s"
+
+        assert {:error, _} = result
+
+        :ok = Sqlite3.execute(db1, "ROLLBACK")
+        Sqlite3.close(db1)
+        Sqlite3.close(db2)
+      end)
+    end
+
+    test "cancelled connection can be reused after reset" do
+      with_file_db(fn path ->
+        {:ok, db1} = Sqlite3.open(path)
+        {:ok, db2} = Sqlite3.open(path)
+
+        :ok = Sqlite3.execute(db1, "PRAGMA journal_mode=WAL")
+        :ok = Sqlite3.execute(db1, "CREATE TABLE t (i INTEGER)")
+        :ok = Sqlite3.execute(db1, "INSERT INTO t VALUES(1)")
+
+        :ok = Sqlite3.set_busy_timeout(db2, 60_000)
+
+        :ok = Sqlite3.execute(db1, "BEGIN IMMEDIATE")
+        :ok = Sqlite3.execute(db1, "INSERT INTO t VALUES(2)")
+
+        parent = self()
+
+        spawn(fn ->
+          result = Sqlite3.execute(db2, "INSERT INTO t VALUES(3)")
+          send(parent, {:write_result, result})
+        end)
+
+        Process.sleep(200)
+        :ok = Sqlite3.cancel(db2)
+
+        receive do
+          {:write_result, _} -> :ok
+        after
+          2_000 -> flunk("cancel did not break through busy handler")
+        end
+
+        # Release the lock
+        :ok = Sqlite3.execute(db1, "ROLLBACK")
+
+        # db2 should be usable again for reads and writes
+        assert {:ok, _stmt} = Sqlite3.prepare(db2, "SELECT * FROM t")
+        assert :ok = Sqlite3.execute(db2, "INSERT INTO t VALUES(99)")
+
+        Sqlite3.close(db1)
+        Sqlite3.close(db2)
+      end)
+    end
+
+    test "cancel on closed connection is a no-op" do
+      {:ok, conn} = Sqlite3.open(":memory:")
+      :ok = Sqlite3.close(conn)
+
+      # cancel on a closed connection is safe (same as interrupt)
+      assert :ok = Sqlite3.cancel(conn)
+    end
+  end
 end

--- a/test/exqlite/sqlite3_test.exs
+++ b/test/exqlite/sqlite3_test.exs
@@ -1362,7 +1362,10 @@ defmodule Exqlite.Sqlite3Test do
         parent = self()
 
         spawn(fn -> send(parent, {:close, Sqlite3.close(conn)}) end)
-        spawn(fn -> send(parent, {:busy_timeout, Sqlite3.set_busy_timeout(conn, timeout_ms)}) end)
+
+        spawn(fn ->
+          send(parent, {:busy_timeout, Sqlite3.set_busy_timeout(conn, timeout_ms)})
+        end)
 
         assert_receive {:close, :ok}, 1000
 
@@ -1443,7 +1446,8 @@ defmodule Exqlite.Sqlite3Test do
       {:ok, conn} = Sqlite3.open(":memory:")
       :ok = Sqlite3.close(conn)
 
-      assert {:error, :connection_closed} = Sqlite3.set_progress_handler_steps(conn, 5_000)
+      assert {:error, :connection_closed} =
+               Sqlite3.set_progress_handler_steps(conn, 5_000)
     end
 
     test "concurrent close and set_progress_handler_steps does not segfault" do
@@ -1454,7 +1458,10 @@ defmodule Exqlite.Sqlite3Test do
         spawn(fn -> send(parent, {:close, Sqlite3.close(conn)}) end)
 
         spawn(fn ->
-          send(parent, {:progress_steps, Sqlite3.set_progress_handler_steps(conn, steps)})
+          send(
+            parent,
+            {:progress_steps, Sqlite3.set_progress_handler_steps(conn, steps)}
+          )
         end)
 
         assert_receive {:close, :ok}, 1000

--- a/test/exqlite/sqlite3_test.exs
+++ b/test/exqlite/sqlite3_test.exs
@@ -1012,6 +1012,15 @@ defmodule Exqlite.Sqlite3Test do
       end
     end
 
+    test "concurrent cancel and close does not segfault" do
+      for _ <- 1..500 do
+        {:ok, conn} = Sqlite3.open(":memory:")
+        task = Task.async(fn -> Sqlite3.cancel(conn) end)
+        Sqlite3.close(conn)
+        Task.await(task, 1000)
+      end
+    end
+
     test "concurrent double close does not segfault" do
       for _ <- 1..200 do
         {:ok, conn} = Sqlite3.open(":memory:")
@@ -1340,6 +1349,28 @@ defmodule Exqlite.Sqlite3Test do
       Sqlite3.close(conn)
     end
 
+    test "closed connection returns connection_closed" do
+      {:ok, conn} = Sqlite3.open(":memory:")
+      :ok = Sqlite3.close(conn)
+
+      assert {:error, :connection_closed} = Sqlite3.set_busy_timeout(conn, 5000)
+    end
+
+    test "concurrent close and set_busy_timeout does not segfault" do
+      for timeout_ms <- [0, 1, 50, 5_000], _ <- 1..100 do
+        {:ok, conn} = Sqlite3.open(":memory:")
+        parent = self()
+
+        spawn(fn -> send(parent, {:close, Sqlite3.close(conn)}) end)
+        spawn(fn -> send(parent, {:busy_timeout, Sqlite3.set_busy_timeout(conn, timeout_ms)}) end)
+
+        assert_receive {:close, :ok}, 1000
+
+        assert_receive {:busy_timeout, result}, 1000
+        assert result in [:ok, {:error, :connection_closed}]
+      end
+    end
+
     test "timeout of 0 causes immediate SQLITE_BUSY" do
       with_file_db(fn path ->
         {:ok, db1} = Sqlite3.open(path)
@@ -1398,6 +1429,42 @@ defmodule Exqlite.Sqlite3Test do
     end
   end
 
+  describe ".set_progress_handler_steps/2" do
+    test "accepts disabling and re-enabling the progress handler" do
+      {:ok, conn} = Sqlite3.open(":memory:")
+
+      assert :ok = Sqlite3.set_progress_handler_steps(conn, -1)
+      assert :ok = Sqlite3.set_progress_handler_steps(conn, 5_000)
+
+      Sqlite3.close(conn)
+    end
+
+    test "closed connection returns connection_closed" do
+      {:ok, conn} = Sqlite3.open(":memory:")
+      :ok = Sqlite3.close(conn)
+
+      assert {:error, :connection_closed} = Sqlite3.set_progress_handler_steps(conn, 5_000)
+    end
+
+    test "concurrent close and set_progress_handler_steps does not segfault" do
+      for steps <- [-1, 1, 1_000, 50_000], _ <- 1..100 do
+        {:ok, conn} = Sqlite3.open(":memory:")
+        parent = self()
+
+        spawn(fn -> send(parent, {:close, Sqlite3.close(conn)}) end)
+
+        spawn(fn ->
+          send(parent, {:progress_steps, Sqlite3.set_progress_handler_steps(conn, steps)})
+        end)
+
+        assert_receive {:close, :ok}, 1000
+
+        assert_receive {:progress_steps, result}, 1000
+        assert result in [:ok, {:error, :connection_closed}]
+      end
+    end
+  end
+
   # -- New NIF: cancel/1 -------------------------------------------------------
 
   describe ".cancel/1" do
@@ -1420,6 +1487,7 @@ defmodule Exqlite.Sqlite3Test do
 
         # db2 gets a long busy timeout — without cancel, it would wait 60s
         :ok = Sqlite3.set_busy_timeout(db2, 60_000)
+        :ok = Sqlite3.set_progress_handler_steps(db2, -1)
 
         # db1 holds exclusive lock
         :ok = Sqlite3.execute(db1, "BEGIN IMMEDIATE")

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,1 @@
-ExUnit.start(capture_log: true, timeout: 120_000, exclude: [:slow_test])
+ExUnit.start(capture_log: true, timeout: 120_000, exclude: [:slow_test, :sanitizer])


### PR DESCRIPTION
Partially addresses [elixir-sqlite/exqlite#192](https://github.com/elixir-sqlite/exqlite/issues/192).

## Summary

This PR fixes a deadlock where `DBConnection.disconnect/2` could block forever while closing a connection whose dirty NIF thread was still inside SQLite. The dirty NIF execution model is unchanged; the fix is to make the blocked SQLite operation cancellable so it can release `conn->mutex` and allow close to finish.

The deadlock can happen in two important cases: a long-running statement inside SQLite VDBE execution, or a statement sleeping in SQLite's busy handler while waiting for a lock. In both cases the NIF call holds `conn->mutex`. If the pool times out and disconnect tries to close the connection, close also needs `conn->mutex`, so it waits behind the stuck operation.

## What changed

This adds `Exqlite.Sqlite3.cancel/1`, which sets a connection cancellation flag and calls `sqlite3_interrupt()`. `Exqlite.Connection.disconnect/2` now calls `cancel/1` before `close/1`, so teardown can interrupt a running statement or cause a busy wait to stop retrying.

This replaces SQLite's default busy handler with an Exqlite busy handler. The handler preserves SQLite's default retry delay schedule, stores the timeout in `conn->busy_timeout_ms`, sleeps with `sqlite3_sleep()`, and checks the cancellation flag between sleeps. This avoids the non-cancellable behavior of SQLite's default busy handler while keeping the implementation portable.

This adds `Exqlite.Sqlite3.set_busy_timeout/2` and changes connection setup to use it instead of `PRAGMA busy_timeout`. `PRAGMA busy_timeout` calls `sqlite3_busy_timeout()`, which installs SQLite's default busy handler and replaces any custom handler. The new API updates Exqlite's stored timeout without destroying the cancellable busy handler.

This adds a configurable progress handler interval through `Exqlite.Sqlite3.set_progress_handler_steps/2` and the `:progress_handler_steps` connection option. The default is `1000` VDBE steps. Values less than `1` disable the progress handler for callers that want to avoid that overhead.

The shared cancellation flag is protected by `interrupt_mutex`. The busy handler, progress handler, `cancel/1`, and close/destructor paths read or write that flag under the same lock. The busy-timeout and progress-handler-step fields are also updated under `interrupt_mutex`.

## User-facing behavior

High-level users who configure `:busy_timeout` on `Exqlite.start_link/1` or an Ecto SQLite repo should not need to change anything. The connection setup path now applies that timeout through `Exqlite.Sqlite3.set_busy_timeout/2`.

Low-level users who execute `PRAGMA busy_timeout = ...` directly should migrate to `Exqlite.Sqlite3.set_busy_timeout/2` if they want to keep cancellation of busy waits. Executing the pragma still works as SQLite behavior, but it replaces Exqlite's custom busy handler with SQLite's default handler, so `cancel/1` can no longer stop the busy-handler retry loop before SQLite's busy timeout expires.

`Exqlite.Sqlite3.interrupt/1` remains available for SQLite interruption. `Exqlite.Sqlite3.cancel/1` is the stronger teardown-oriented API because it sets Exqlite's cancellation flag for the busy/progress handlers and also calls `sqlite3_interrupt()`.

## Implementation notes

The busy handler uses SQLite's default delay schedule: `1, 2, 5, 10, 15, 20, 25, 25, 25, 50, 50` ms, then `50` ms for later retries. Cancellation is observed between sleep intervals, so a busy wait exits after the current sleep finishes, with later sleeps capped at 50 ms.

The NIF stores the calling environment and pid while SQLite operations are running so the busy handler can detect when the caller process has died. If the caller is gone, the busy handler sets the cancellation flag and stops retrying.

`cancel/1` and `interrupt/1` avoid taking `conn->mutex` while a query may be running. A running SQLite call holds that mutex, so taking it in the cancellation path would block behind the operation we are trying to cancel. The timeout/progress configuration setters still take `conn->mutex` because they are not used to break a currently running SQLite call.

The NIF resource destructor and close path coordinate through `conn->mutex` and `interrupt_mutex` so connection teardown does not race with cancellation state updates or a concurrent interrupt.

The Mix project now tracks the C source files as external resources, and the Makefile emits dependency files for C headers, so C/NIF changes are rebuilt more reliably.

## Tests

This PR adds regression coverage for busy-timeout behavior, low-level `set_busy_timeout/2`, configurable progress-handler steps, `cancel/1`, connection reuse after cancellation, pool recovery after timeouts, cancellation of busy-handler waits, and close/cancel races.

It also adds sanitizer-tagged stress tests for the cancellation and busy-timeout update paths. Those tests are excluded from the default suite and can be run explicitly with `--include sanitizer`.